### PR TITLE
Fix Windows build, exclude WASM builds

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -28,6 +28,9 @@ jobs:
       duckdb_version: v1.4.2
       ci_tools_version: v1.4.2
       extension_name: read_rdf
+      # Exclude WASM builds: serd uses meson which requires pkgconf, and pkgconf
+      # cannot be compiled to wasm32-emscripten (it's a host tool, not a target)
+      exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
 
   code-quality-check:
     name: Code Quality Check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,17 @@ build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
 target_link_libraries(${EXTENSION_NAME} PkgConfig::SERD)
-target_include_directories(${EXTENSION_NAME} PRIVATE ${SERD_INCLUDE_DIRS}) 
+target_include_directories(${EXTENSION_NAME} PRIVATE ${SERD_INCLUDE_DIRS})
 
 target_link_libraries(${LOADABLE_EXTENSION_NAME} PkgConfig::SERD)
 target_include_directories(${LOADABLE_EXTENSION_NAME} PRIVATE ${SERD_INCLUDE_DIRS})
+
+# On Windows, serd is built as a static library via vcpkg, but the headers default to
+# dllimport. Define SERD_STATIC to use static linking and avoid LNK2019/LNK1120 errors.
+if(WIN32)
+    target_compile_definitions(${EXTENSION_NAME} PRIVATE SERD_STATIC)
+    target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE SERD_STATIC)
+endif()
 
 install(
   TARGETS ${EXTENSION_NAME}


### PR DESCRIPTION
## Summary of Fixes

### 1. Windows Build Fix (CMakeLists.txt)

**Problem:** Linker errors LNK2019/LNK1120 - all serd functions had __imp_ prefix indicating the compiler expected DLL imports, but vcpkg builds serd as a static library.

**Fix:** Added SERD_STATIC compile definition on Windows:
```cmake
if(WIN32)
    target_compile_definitions(${EXTENSION_NAME} PRIVATE SERD_STATIC)
    target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE SERD_STATIC)
endif()
```

### 2. WASM Build Fix (MainDistributionPipeline.yml)

**Problem:** vcpkg tries to build pkgconf:wasm32-emscripten but pkgconf is a host tool that cannot be compiled to WASM. The serd library uses meson build system which requires pkgconf.

**Fix:** Excluded all WASM platforms from CI:
```yaml
exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads'
```

### What "Excluding WASM" Actually Means

- Users running DuckDB in browsers (duckdb-wasm) cannot use this extension
- We're avoiding the problem, not solving it
- It's a workaround, not a fix