### PR TITLE
Inline serd

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -28,12 +28,9 @@ jobs:
       duckdb_version: v1.4.2
       ci_tools_version: v1.4.2
       extension_name: read_rdf
-      # Run only Windows for testing the fopen fix
-      exclude_archs: 'linux_amd64;linux_amd64_gcc4;linux_arm64;osx_amd64;osx_arm64;wasm_mvp;wasm_eh;wasm_threads'
 
   code-quality-check:
     name: Code Quality Check
-    if: false  # Disabled temporarily - testing Windows only
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.4.2
     with:
       duckdb_version: v1.4.2


### PR DESCRIPTION
Windows does not support - e flag 

https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170&viewFallbackFrom=msvc-170

FILE *_f = std::fopen(file_path.c_str(), "rbe");  As my understanding "e" flag is GNU glibc extension. Windows does not recognize it so it was failing. 