### PR TITLE
Fix Windows build by enabling SERD_STATIC for static linking of serd sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
+
+# Correct placement: define SERD_STATIC before compiling serd sources
+if(WIN32)
+    add_definitions(-DSERD_STATIC)
+endif()
+
 include_directories(src/include)
 
 set(EXTENSION_SOURCES src/read_rdf_extension.cpp src/serd_buffer.cpp src/base64.c src/byte_source.c src/env.c src/n3.c src/node.c src/reader.c src/string.c src/system.c src/uri.c src/writer.c)
@@ -22,10 +28,10 @@ build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
 # On Windows, serd is built as a static library, but the headers default to
 # dllimport. Define SERD_STATIC to use static linking and avoid LNK2019/LNK1120 errors.
-if(WIN32)
-    target_compile_definitions(${EXTENSION_NAME} PRIVATE SERD_STATIC)
-    target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE SERD_STATIC)
-endif()
+#if(WIN32)
+#    target_compile_definitions(${EXTENSION_NAME} PRIVATE SERD_STATIC)
+#    target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE SERD_STATIC)
+#endif()
 
 install(
   TARGETS ${EXTENSION_NAME}


### PR DESCRIPTION
Fix Windows build by applying SERD_STATIC early so the vendored serd sources
compile in static mode. This prevents dllimport/__imp_* symbol issues and fixes
the Windows linker errors.

Note:

The vendored serd C files:
 -must not be compiled in DLL-import mode
 -must be compiled as static code
 -must have the macro SERD_STATIC defined
 -otherwise they produce the wrong symbols causing Windows linker failures

Two changes were made:

1) Moved the definition of SERD_STATIC to a position *before* the DuckDB extension helper macros run. This ensures the serd C files see the macro during compilation.

2) Switched from target_compile_definitions() to add_definitions() so that SERD_STATIC is applied globally in this directory. This is necessary because the serd C files are compiled inside internal build targets created by DuckDB’s extension helper macros, not inside ${EXTENSION_NAME} or ${LOADABLE_EXTENSION_NAME}. Global definitions ensure that SERD_STATIC is visible when those internal targets compile the vendored serd sources.