### PR TITLE
fix: install libcurl and libxml2 for tidy-check in CI

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -29,11 +29,46 @@ jobs:
       ci_tools_version: v1.5.0
       extension_name: rdf
 
-  code-quality-check:
-    name: Code Quality Check
+  format-check:
+    name: Format Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5.0
     with:
       duckdb_version: v1.5.0
       ci_tools_version: v1.5.0
       extension_name: rdf
-      format_checks: 'format; tidy' 
+      format_checks: 'format'
+
+  tidy-check:
+    name: Tidy Check
+    runs-on: ubuntu-24.04
+
+    env:
+      CC: gcc
+      CXX: g++
+      GEN: ninja
+      TIDY_THREADS: 4
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout current repository
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: v1.5.0
+          repository: duckdb/extension-ci-tools
+
+      - name: Install
+        shell: bash
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq ninja-build clang-tidy libcurl4-openssl-dev libxml2-dev
+          sudo pip3 install pybind11[global] --break-system-packages
+
+      - name: Tidy Check
+        shell: bash
+        run: make tidy-check


### PR DESCRIPTION
The reusable _extension_code_quality.yml workflow only installs ninja-build and clang-tidy, causing CMake to fail when finding CURL and LibXml2 during the tidy-check configure step.

Split the code-quality-check job: keep the reusable workflow for format-check, and add an inline tidy-check job that installs libcurl4-openssl-dev and libxml2-dev before running make tidy-check.

https://claude.ai/code/session_012Wgh74qm8RuNxa83zVGdYX