### PR TITLE
Add Dependabot configuration for GitHub Actions, npm, and git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/test/wasm-smoke-test"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      duckdb-ecosystem:
+        patterns:
+          - "duckdb"
+          - "extension-ci-tools"


### PR DESCRIPTION
Covers three ecosystems:
- github-actions: keeps actions/checkout and other workflow actions up to date
- npm: tracks wasm smoke-test dependencies in test/wasm-smoke-test/
- gitsubmodule: monitors all four submodules, grouping duckdb + extension-ci-tools together since they share a version cadence


Claude-Session: https://claude.ai/code/session_01CJdxM8kmrnY8pjum1rGJw7