### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/nonodename/duck_rdf/security/code-scanning/4](https://github.com/nonodename/duck_rdf/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so all jobs (including reusable workflow jobs and `tidy-check`) inherit least-privilege token access unless overridden.  
For this file, the minimal safe baseline from CodeQL is:

- `permissions:`
  - `contents: read`

This does not change workflow behavior for the shown steps (checkout/read/build), but removes dependence on external default token settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
