### PR TITLE
Add description and examples metadata to all extension functions

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -43,6 +43,36 @@ jobs:
       ci_tools_version: v1.5.4
       extension_name: rdf
       format_checks: 'format'
+  
+  wasm-smoke-test:
+    name: WASM Smoke Test
+    needs: duckdb-stable-build
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        name: Checkout current repository
+
+      - uses: actions/download-artifact@v4
+        name: Download WASM extension artifact
+        with:
+          name: rdf-v1.5.4-extension-wasm_eh
+          path: wasm-build/
+
+      - uses: actions/setup-node@v4
+        name: Set up Node.js
+        with:
+          node-version: '20'
+
+      - name: Install smoke-test dependencies
+        run: npm ci
+        working-directory: test/wasm-smoke-test
+
+      - name: Run WASM smoke test
+        run: |
+          WASM_PATH=$(find ../../wasm-build -name '*.duckdb_extension.wasm' | head -1)
+          echo "Using WASM extension: $WASM_PATH"
+          node test-wasm-load.mjs "$WASM_PATH"
+        working-directory: test/wasm-smoke-test
 
   tidy-check:
     name: Tidy Check

--- a/src/pivot_rdf.cpp
+++ b/src/pivot_rdf.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/function/table_function.hpp"
+#include <duckdb/parser/parsed_data/create_table_function_info.hpp>
 
 #include <algorithm>
 #include <mutex>
@@ -649,7 +650,16 @@ void RegisterPivotRDF(ExtensionLoader &loader) {
 	tf.named_parameters["file_type"] = LogicalType::VARCHAR;
 	tf.named_parameters["strict_parsing"] = LogicalType::BOOLEAN;
 	tf.named_parameters["prefix_expansion"] = LogicalType::BOOLEAN;
-	loader.RegisterFunction(tf);
+
+	CreateTableFunctionInfo info(tf);
+	FunctionDescription desc;
+	desc.description =
+	    "Read RDF triples and pivot them into a wide table where each distinct predicate becomes a column "
+	    "and subjects become row identifiers.";
+	desc.examples.push_back("SELECT * FROM pivot_rdf('data.ttl')");
+	desc.examples.push_back("SELECT * FROM pivot_rdf('data.nt', prefix_expansion=true)");
+	info.descriptions.push_back(desc);
+	loader.RegisterFunction(std::move(info));
 }
 
 } // namespace duckdb

--- a/src/profile_rdf.cpp
+++ b/src/profile_rdf.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/function/table_function.hpp"
+#include <duckdb/parser/parsed_data/create_table_function_info.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -271,7 +272,16 @@ void RegisterProfileRDF(ExtensionLoader &loader) {
 	                 ProfileRDFLocalInit);
 	tf.named_parameters[PROFILE_FILE_TYPE] = LogicalType::VARCHAR;
 	tf.named_parameters[PROFILE_STRICT_PARSING] = LogicalType::BOOLEAN;
-	loader.RegisterFunction(tf);
+
+	CreateTableFunctionInfo info(tf);
+	FunctionDescription desc;
+	desc.description =
+	    "Profile one or more RDF files and return a predicate-level statistical summary including value counts, "
+	    "datatypes, and cardinalities.";
+	desc.examples.push_back("SELECT * FROM profile_rdf('data.nt')");
+	desc.examples.push_back("SELECT * FROM profile_rdf('data/*.ttl', strict_parsing=false)");
+	info.descriptions.push_back(desc);
+	loader.RegisterFunction(std::move(info));
 }
 
 } // namespace duckdb

--- a/src/r2rml_copy.cpp
+++ b/src/r2rml_copy.cpp
@@ -1,4 +1,5 @@
 #include "include/r2rml_copy.hpp"
+#include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
@@ -615,13 +616,24 @@ static CopyFunctionExecutionMode R2RMLCopyExecutionMode(bool, bool) {
 }
 
 void RegisterR2RMLCopy(ExtensionLoader &loader) {
-	auto can_call_inside_out_scalar_function =
-	    ScalarFunction("can_call_inside_out", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, CanCallInsideOut);
-	loader.RegisterFunction(can_call_inside_out_scalar_function);
+	ScalarFunction can_call_inside_out_sf("can_call_inside_out", {LogicalType::VARCHAR}, LogicalType::BOOLEAN,
+	                                      CanCallInsideOut);
+	CreateScalarFunctionInfo can_call_info(can_call_inside_out_sf);
+	FunctionDescription can_call_desc;
+	can_call_desc.description =
+	    "Return true if the given R2RML mapping file can be executed in inside-out mode, where DuckDB runs "
+	    "the SQL query and the extension maps each output row to RDF triples.";
+	can_call_desc.examples.push_back("SELECT can_call_inside_out('mapping.ttl')");
+	can_call_info.descriptions.push_back(can_call_desc);
+	loader.RegisterFunction(std::move(can_call_info));
 
-	auto is_valid_r2rml_scalar_function =
-	    ScalarFunction("is_valid_r2rml", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, IsValidR2RML);
-	loader.RegisterFunction(is_valid_r2rml_scalar_function);
+	ScalarFunction is_valid_r2rml_sf("is_valid_r2rml", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, IsValidR2RML);
+	CreateScalarFunctionInfo is_valid_info(is_valid_r2rml_sf);
+	FunctionDescription is_valid_desc;
+	is_valid_desc.description = "Return true if the given file is a syntactically valid R2RML mapping document.";
+	is_valid_desc.examples.push_back("SELECT is_valid_r2rml('mapping.ttl')");
+	is_valid_info.descriptions.push_back(is_valid_desc);
+	loader.RegisterFunction(std::move(is_valid_info));
 
 	CopyFunction copy_func("r2rml");
 	copy_func.extension = "nt";

--- a/src/rdf_extension.cpp
+++ b/src/rdf_extension.cpp
@@ -227,7 +227,17 @@ static void LoadInternal(ExtensionLoader &loader) {
 	tf.named_parameters[FILE_TYPE] = LogicalType::VARCHAR;
 	tf.named_parameters[INCLUDE_FILENAMES] = LogicalType::BOOLEAN;
 	tf.projection_pushdown = true;
-	loader.RegisterFunction(tf);
+
+	CreateTableFunctionInfo info(tf);
+	FunctionDescription desc;
+	desc.description =
+	    "Read RDF triples from one or more files (Turtle, NTriples, NQuads, TriG, or RDF/XML) into a table with "
+	    "columns graph, subject, predicate, object, object_datatype, and object_lang. Glob patterns are supported.";
+	desc.examples.push_back("SELECT * FROM read_rdf('data.nt')");
+	desc.examples.push_back("SELECT subject, predicate, object FROM read_rdf('*.ttl')");
+	desc.examples.push_back("SELECT * FROM read_rdf('data.rdf', file_type='rdf', strict_parsing=false)");
+	info.descriptions.push_back(desc);
+	loader.RegisterFunction(std::move(info));
 
 	RegisterR2RMLCopy(loader);
 #ifndef DUCK_RDF_NO_SPARQL

--- a/src/read_rdf_prefixes.cpp
+++ b/src/read_rdf_prefixes.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/function/table_function.hpp"
+#include <duckdb/parser/parsed_data/create_table_function_info.hpp>
 #include <serd/serd.h>
 
 #include <atomic>
@@ -301,7 +302,16 @@ void RegisterReadRDFPrefixes(ExtensionLoader &loader) {
 	tf.named_parameters[PREFIXES_STRICT_PARSING] = LogicalType::BOOLEAN;
 	tf.named_parameters[PREFIXES_FILE_TYPE] = LogicalType::VARCHAR;
 	tf.named_parameters[PREFIXES_INCLUDE_FILENAMES] = LogicalType::BOOLEAN;
-	loader.RegisterFunction(tf);
+
+	CreateTableFunctionInfo info(tf);
+	FunctionDescription desc;
+	desc.description =
+	    "Read the namespace prefix declarations from one or more RDF files. Returns prefix (local name), "
+	    "uri (namespace URI), and is_base (true for @base declarations) columns.";
+	desc.examples.push_back("SELECT * FROM read_rdf_prefixes('data.ttl')");
+	desc.examples.push_back("SELECT prefix, uri FROM read_rdf_prefixes('*.ttl')");
+	info.descriptions.push_back(desc);
+	loader.RegisterFunction(std::move(info));
 }
 
 } // namespace duckdb

--- a/src/sparql_reader.cpp
+++ b/src/sparql_reader.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/function/table_function.hpp"
+#include <duckdb/parser/parsed_data/create_table_function_info.hpp>
 
 #include <curl/curl.h>
 #include <atomic>
@@ -313,7 +314,16 @@ static void SPARQLFunc(ClientContext &context, TableFunctionInput &input, DataCh
 void RegisterSPARQLReader(ExtensionLoader &loader) {
 	TableFunction tf("read_sparql", {LogicalType::VARCHAR, LogicalType::VARCHAR}, SPARQLFunc, SPARQLBind,
 	                 SPARQLGlobalInit);
-	loader.RegisterFunction(tf);
+
+	CreateTableFunctionInfo info(tf);
+	FunctionDescription desc;
+	desc.description =
+	    "Execute a SPARQL SELECT query against a remote endpoint and return the results as a table. "
+	    "Each SPARQL variable becomes a VARCHAR column. Not available in WebAssembly builds.";
+	desc.examples.push_back(
+	    "SELECT * FROM read_sparql('https://dbpedia.org/sparql', 'SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10')");
+	info.descriptions.push_back(desc);
+	loader.RegisterFunction(std::move(info));
 }
 
 } // namespace duckdb

--- a/src/sparql_reader.cpp
+++ b/src/sparql_reader.cpp
@@ -317,9 +317,8 @@ void RegisterSPARQLReader(ExtensionLoader &loader) {
 
 	CreateTableFunctionInfo info(tf);
 	FunctionDescription desc;
-	desc.description =
-	    "Execute a SPARQL SELECT query against a remote endpoint and return the results as a table. "
-	    "Each SPARQL variable becomes a VARCHAR column. Not available in WebAssembly builds.";
+	desc.description = "Execute a SPARQL SELECT query against a remote endpoint and return the results as a table. "
+	                   "Each SPARQL variable becomes a VARCHAR column. Not available in WebAssembly builds.";
 	desc.examples.push_back(
 	    "SELECT * FROM read_sparql('https://dbpedia.org/sparql', 'SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10')");
 	info.descriptions.push_back(desc);

--- a/test/sql/function_metadata.test
+++ b/test/sql/function_metadata.test
@@ -1,0 +1,89 @@
+# name: test/sql/function_metadata.test
+# description: verify duckdb_functions() description and examples are set for all extension functions
+# group: [sql]
+
+require rdf
+
+# ── read_rdf ──────────────────────────────────────────────────────────────────
+
+query I
+SELECT description IS NOT NULL FROM duckdb_functions() WHERE function_name = 'read_rdf' LIMIT 1;
+----
+true
+
+query I
+SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'read_rdf' LIMIT 1;
+----
+true
+
+# ── profile_rdf ───────────────────────────────────────────────────────────────
+
+query I
+SELECT description IS NOT NULL FROM duckdb_functions() WHERE function_name = 'profile_rdf' LIMIT 1;
+----
+true
+
+query I
+SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'profile_rdf' LIMIT 1;
+----
+true
+
+# ── pivot_rdf ─────────────────────────────────────────────────────────────────
+
+query I
+SELECT description IS NOT NULL FROM duckdb_functions() WHERE function_name = 'pivot_rdf' LIMIT 1;
+----
+true
+
+query I
+SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'pivot_rdf' LIMIT 1;
+----
+true
+
+# ── read_rdf_prefixes ─────────────────────────────────────────────────────────
+
+query I
+SELECT description IS NOT NULL FROM duckdb_functions() WHERE function_name = 'read_rdf_prefixes' LIMIT 1;
+----
+true
+
+query I
+SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'read_rdf_prefixes' LIMIT 1;
+----
+true
+
+# ── read_sparql ───────────────────────────────────────────────────────────────
+
+query I
+SELECT description IS NOT NULL FROM duckdb_functions() WHERE function_name = 'read_sparql' LIMIT 1;
+----
+true
+
+query I
+SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'read_sparql' LIMIT 1;
+----
+true
+
+# ── can_call_inside_out ───────────────────────────────────────────────────────
+
+query I
+SELECT description IS NOT NULL FROM duckdb_functions() WHERE function_name = 'can_call_inside_out' LIMIT 1;
+----
+true
+
+query I
+SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'can_call_inside_out' LIMIT 1;
+----
+true
+
+# ── is_valid_r2rml ────────────────────────────────────────────────────────────
+
+query I
+SELECT description IS NOT NULL FROM duckdb_functions() WHERE function_name = 'is_valid_r2rml' LIMIT 1;
+----
+true
+
+query I
+SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'is_valid_r2rml' LIMIT 1;
+----
+true


### PR DESCRIPTION
Populates the description and examples fields visible in duckdb_functions()
for read_rdf, read_sparql, profile_rdf, pivot_rdf, read_rdf_prefixes,
can_call_inside_out, and is_valid_r2rml by switching from
loader.RegisterFunction(TableFunction) to the
loader.RegisterFunction(CreateTableFunctionInfo) overload and attaching a
FunctionDescription to each registration.

Adds test/sql/function_metadata.test to assert that description IS NOT NULL
and len(examples) > 0 for every registered function.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CK6Cd9wK2NsYTPp5ADMvkS