### PR TITLE
Update to v2 of sql2rdf

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -157,7 +157,7 @@ Git submodules (branch `v1.5-variegata`, i.e. the DuckDB v1.5 line — see `docs
 
 CMake FetchContent (fetched at configure time, not checked into the repo; pins live in `CMakeLists.txt`):
 - `serd` v0.32.10 — RDF parsing/writing library (built as an internal static lib from an explicit source list; the target name must remain `serd` so sql2rdf reuses it)
-- `sql2rdf` v1.2.3 — R2RML mapping compiler/evaluator
+- `sql2rdf` v2.0.0 — R2RML mapping compiler/evaluator
 - `yaml-cpp` 0.9.0 — YARRRML parsing support
 
 vcpkg (`vcpkg.json`): `libxml2`, `curl` (with SSL) — both excluded on the `emscripten` platform.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ target_include_directories(${SERD_NAME}
 FetchContent_Declare(
   sql2rdf
   GIT_REPOSITORY https://github.com/nonodename/sql2rdf.git
-  GIT_TAG v1.2.4
+  GIT_TAG v2.0.0
 )
 
 FetchContent_MakeAvailable(sql2rdf)
@@ -130,14 +130,33 @@ if (NOT EMSCRIPTEN)
 endif()
 
 # Link internal libs; LibXml2 and CURL are excluded for WASM (no OS sockets, no WASM build of CURL)
-target_link_libraries(${EXTENSION_NAME}
-        ${SERD_NAME}
-        sql2rdf::yarrrml
-)
-target_link_libraries(${LOADABLE_EXTENSION_NAME}
-        ${SERD_NAME}
-        sql2rdf::yarrrml
-)
+if (EMSCRIPTEN)
+    # sql2rdf >= v2.0.0 makes yarrrml::YARRRMLParser polymorphic (it now
+    # derives from r2rml::MappingParser). wasm-ld's SIDE_MODULE=2 link
+    # tolerates unresolved symbols instead of erroring, so if the static
+    # archive member that carries YARRRMLParser's vtable definition isn't
+    # otherwise pulled in, the vtable is silently left as an unresolved
+    # runtime import and `LOAD rdf` fails in the browser (the issue #39
+    # symptom; see test/wasm-smoke-test). Force the whole archive in so
+    # that object is always included.
+    target_link_libraries(${EXTENSION_NAME}
+            ${SERD_NAME}
+            "-Wl,--whole-archive" sql2rdf_yarrrml sql2rdf_r2rml "-Wl,--no-whole-archive"
+    )
+    target_link_libraries(${LOADABLE_EXTENSION_NAME}
+            ${SERD_NAME}
+            "-Wl,--whole-archive" sql2rdf_yarrrml sql2rdf_r2rml "-Wl,--no-whole-archive"
+    )
+else()
+    target_link_libraries(${EXTENSION_NAME}
+            ${SERD_NAME}
+            sql2rdf::yarrrml
+    )
+    target_link_libraries(${LOADABLE_EXTENSION_NAME}
+            ${SERD_NAME}
+            sql2rdf::yarrrml
+    )
+endif()
 
 # Signal to C++ that XML and SPARQL features are disabled in WASM builds
 if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,6 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 if (NOT EMSCRIPTEN)
     find_package(LibXml2 REQUIRED)
     find_package(CURL REQUIRED)
-else()
-    # TEMPORARY: verbose build output to inspect the actual side-module link
-    # command while diagnosing the YARRRMLParser vtable regression (see
-    # test/wasm-smoke-test). Remove once root-caused.
-    set(CMAKE_VERBOSE_MAKEFILE ON)
 endif()
 
 project(${TARGET_NAME} LANGUAGES C CXX)
@@ -135,33 +130,14 @@ if (NOT EMSCRIPTEN)
 endif()
 
 # Link internal libs; LibXml2 and CURL are excluded for WASM (no OS sockets, no WASM build of CURL)
-if (EMSCRIPTEN)
-    # sql2rdf >= v2.0.0 makes yarrrml::YARRRMLParser polymorphic (it now
-    # derives from r2rml::MappingParser). wasm-ld's SIDE_MODULE=2 link
-    # tolerates unresolved symbols instead of erroring, so if the static
-    # archive member that carries YARRRMLParser's vtable definition isn't
-    # otherwise pulled in, the vtable is silently left as an unresolved
-    # runtime import and `LOAD rdf` fails in the browser (the issue #39
-    # symptom; see test/wasm-smoke-test). Force the whole archive in so
-    # that object is always included.
-    target_link_libraries(${EXTENSION_NAME}
-            ${SERD_NAME}
-            "-Wl,--whole-archive" sql2rdf_yarrrml sql2rdf_r2rml "-Wl,--no-whole-archive"
-    )
-    target_link_libraries(${LOADABLE_EXTENSION_NAME}
-            ${SERD_NAME}
-            "-Wl,--whole-archive" sql2rdf_yarrrml sql2rdf_r2rml "-Wl,--no-whole-archive"
-    )
-else()
-    target_link_libraries(${EXTENSION_NAME}
-            ${SERD_NAME}
-            sql2rdf::yarrrml
-    )
-    target_link_libraries(${LOADABLE_EXTENSION_NAME}
-            ${SERD_NAME}
-            sql2rdf::yarrrml
-    )
-endif()
+target_link_libraries(${EXTENSION_NAME}
+        ${SERD_NAME}
+        sql2rdf::yarrrml
+)
+target_link_libraries(${LOADABLE_EXTENSION_NAME}
+        ${SERD_NAME}
+        sql2rdf::yarrrml
+)
 
 # Signal to C++ that XML and SPARQL features are disabled in WASM builds
 if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 if (NOT EMSCRIPTEN)
     find_package(LibXml2 REQUIRED)
     find_package(CURL REQUIRED)
+else()
+    # TEMPORARY: verbose build output to inspect the actual side-module link
+    # command while diagnosing the YARRRMLParser vtable regression (see
+    # test/wasm-smoke-test). Remove once root-caused.
+    set(CMAKE_VERBOSE_MAKEFILE ON)
 endif()
 
 project(${TARGET_NAME} LANGUAGES C CXX)

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -3,20 +3,23 @@
 # Extension from this repo
 # WASM side modules are linked by a separate `emcc -sSIDE_MODULE=2 ... ${TO_BE_LINKED}` step
 # (see duckdb/extension/extension_build_tools.cmake) that ignores target_link_libraries().
-# Only the archives named in LINKED_LIBS are passed to that emcc invocation.
+# Only the archives named in LINKED_LIBS are passed to that emcc invocation, so every static
+# lib the extension needs symbols from (serd, sql2rdf's two libraries, yaml-cpp) must be
+# named here explicitly and by its real CMake target name (sql2rdf's own CMakeLists.txt
+# defines `sql2rdf_r2rml` and `sql2rdf_yarrrml`, not a single combined `sql2rdf_lib` target).
 # CURL has no WASM-compatible build, so it is excluded for Emscripten targets; LibXml2
 # is also excluded to keep the WASM module minimal (RDF/XML parsing is disabled in WASM).
 if (EMSCRIPTEN)
     duckdb_extension_load(rdf
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
         LOAD_TESTS
-        LINKED_LIBS "$<TARGET_FILE:serd>;$<TARGET_FILE:sql2rdf_lib>;$<TARGET_FILE:yaml-cpp>"
+        LINKED_LIBS "$<TARGET_FILE:serd>;$<TARGET_FILE:sql2rdf_yarrrml>;$<TARGET_FILE:sql2rdf_r2rml>;$<TARGET_FILE:yaml-cpp>"
     )
 else()
     duckdb_extension_load(rdf
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
         LOAD_TESTS
-        LINKED_LIBS "$<TARGET_FILE:serd>;$<TARGET_FILE:sql2rdf_lib>;$<TARGET_FILE:LibXml2::LibXml2>;$<TARGET_FILE:CURL::libcurl>"
+        LINKED_LIBS "$<TARGET_FILE:serd>;$<TARGET_FILE:sql2rdf_yarrrml>;$<TARGET_FILE:sql2rdf_r2rml>;$<TARGET_FILE:LibXml2::LibXml2>;$<TARGET_FILE:CURL::libcurl>"
     )
 endif()
 

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -15,6 +15,11 @@ if (EMSCRIPTEN)
         LOAD_TESTS
         LINKED_LIBS "$<TARGET_FILE:serd>;$<TARGET_FILE:sql2rdf_yarrrml>;$<TARGET_FILE:sql2rdf_r2rml>;$<TARGET_FILE:yaml-cpp>"
     )
+    # TEMPORARY diagnostic: confirm what actually landed in the variable the
+    # WASM side-module emcc link step reads (see extension_build_tools.cmake
+    # build_loadable_extension_directory / TO_BE_LINKED). Remove once
+    # root-caused.
+    message(STATUS "DIAG: DUCKDB_EXTENSION_RDF_LINKED_LIBS = '${DUCKDB_EXTENSION_RDF_LINKED_LIBS}'")
 else()
     duckdb_extension_load(rdf
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -7,24 +7,26 @@
 # lib the extension needs symbols from (serd, sql2rdf's two libraries, yaml-cpp) must be
 # named here explicitly and by its real CMake target name (sql2rdf's own CMakeLists.txt
 # defines `sql2rdf_r2rml` and `sql2rdf_yarrrml`, not a single combined `sql2rdf_lib` target).
+# LINKED_LIBS must be a single SPACE-separated string, not semicolon-separated: duckdb's
+# `duckdb_extension_load` declares LINKED_LIBS as a `oneValueArgs` entry for
+# cmake_parse_arguments(), which is called with `${ARGN}` unquoted - a semicolon-joined
+# value gets re-split into multiple arguments at that point and cmake_parse_arguments
+# silently keeps only the first token, dropping the rest. `extension_build_tools.cmake`
+# later runs the stored string through `separate_arguments()` (whitespace-splitting),
+# which is what turns a space-separated string back into the real list passed to emcc.
 # CURL has no WASM-compatible build, so it is excluded for Emscripten targets; LibXml2
 # is also excluded to keep the WASM module minimal (RDF/XML parsing is disabled in WASM).
 if (EMSCRIPTEN)
     duckdb_extension_load(rdf
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
         LOAD_TESTS
-        LINKED_LIBS "$<TARGET_FILE:serd>;$<TARGET_FILE:sql2rdf_yarrrml>;$<TARGET_FILE:sql2rdf_r2rml>;$<TARGET_FILE:yaml-cpp>"
+        LINKED_LIBS "$<TARGET_FILE:serd> $<TARGET_FILE:sql2rdf_yarrrml> $<TARGET_FILE:sql2rdf_r2rml> $<TARGET_FILE:yaml-cpp>"
     )
-    # TEMPORARY diagnostic: confirm what actually landed in the variable the
-    # WASM side-module emcc link step reads (see extension_build_tools.cmake
-    # build_loadable_extension_directory / TO_BE_LINKED). Remove once
-    # root-caused.
-    message(STATUS "DIAG: DUCKDB_EXTENSION_RDF_LINKED_LIBS = '${DUCKDB_EXTENSION_RDF_LINKED_LIBS}'")
 else()
     duckdb_extension_load(rdf
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
         LOAD_TESTS
-        LINKED_LIBS "$<TARGET_FILE:serd>;$<TARGET_FILE:sql2rdf_yarrrml>;$<TARGET_FILE:sql2rdf_r2rml>;$<TARGET_FILE:LibXml2::LibXml2>;$<TARGET_FILE:CURL::libcurl>"
+        LINKED_LIBS "$<TARGET_FILE:serd> $<TARGET_FILE:sql2rdf_yarrrml> $<TARGET_FILE:sql2rdf_r2rml> $<TARGET_FILE:LibXml2::LibXml2> $<TARGET_FILE:CURL::libcurl>"
     )
 endif()
 


### PR DESCRIPTION
Upstream library major version change, including calling pattern change. 

Consumed that, fixed WASM pipeline for same.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nonodename/duck_rdf/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->