### PR TITLE
Execute sparql function

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,7 @@ A DuckDB extension (extension name: `rdf`) for reading and writing RDF data dire
 | `is_valid_r2rml(path)` | scalar function | Validates an R2RML/YARRRML mapping file |
 | `can_call_inside_out(path)` | scalar function | True if a mapping can be used in inside-out COPY mode |
 | `sparql_to_sql(sparql, mapping)` | scalar function | Translates a SPARQL SELECT/ASK query into an equivalent SQL query against a full R2RML/YARRRML mapping |
+| `execute_sparql(sparql, mapping)` | table function | Translates a SPARQL SELECT/ASK query like `sparql_to_sql`, then runs it, spliced into the calling query's own plan |
 | `COPY ... TO ... (FORMAT r2rml, mapping '...')` | copy function | Writes query results to RDF via an R2RML or YARRRML mapping |
 
 All four file-reading table functions accept a single path, a glob pattern, or a `LIST(VARCHAR)` of paths/globs, and transparently read `.gz` / `.zst` compressed files (decompression is auto-detected via DuckDB's FileSystem).
@@ -146,6 +147,10 @@ Copy options: `mapping` (required), `rdf_format` (`ntriples` default, `turtle`, 
 
 `src/sparql_to_sql.cpp` registers the `sparql_to_sql(sparql, mapping)` scalar function, using the `sql2rdf` library's `sparql2sql` module (SPARQL 1.1 parser + R2RML-mapping-in-reverse translator) to compile a SPARQL SELECT/ASK query into a standalone SQL query for the `duckdb` dialect (`sparql2sql::DuckDbDialect`, the only dialect the library currently implements). The mapping is parsed with `ParseR2RMLOrYarrrmlMapping` (declared in `src/include/r2rml_copy.hpp`, shared with `r2rml_copy.cpp`) and must be a *full* R2RML mapping (`mapping.isValid()`, i.e. every `TriplesMap` has an `rr:logicalTable`/YARRRML `sources`) — inside-out-only mappings are rejected, since there is no live SQL connection here to bounce rows through the way `COPY ... FORMAT r2rml` does. Errors from each stage (missing/unparsable mapping file, a mapping missing logical tables, SPARQL syntax errors via `sparql::ParseError`, unsupported constructs via `sparql2sql::TranslationError`) are rethrown as DuckDB exceptions with a stage-identifying prefix. Unlike `read_sparql`/RDF-XML, this has no curl/libxml2 dependency (`sql2rdf::sparql2sql` only depends on `sql2rdf_r2rml` and the freestanding `sql2rdf_sparql` grammar parser), so it is registered unconditionally and works in WASM builds too.
 
+The translation pipeline itself (mapping load/validate → SPARQL parse → `translateQuery`) is factored out as `TranslateSparqlToSql` (declared in `src/include/sparql_to_sql.hpp`) so it's shared byte-for-byte between `sparql_to_sql` and `src/execute_sparql.cpp`'s `execute_sparql(sparql, mapping)` table function — both raise identical errors.
+
+`execute_sparql` does *not* implement a normal `Bind`/`Scan` table function. Instead it sets `TableFunction::bind_replace`, a DuckDB mechanism that lets a table function's bind step return a `unique_ptr<TableRef>` in place of bind data — DuckDB's binder (`bind_table_function.cpp`) then recurses `Bind()` on that `TableRef` using the *same* `Binder`/`bind_context` building the outer query, exactly as if it were a hand-written subquery. `execute_sparql`'s `bind_replace` parses the SQL returned by `TranslateSparqlToSql` with `Parser::ParseQuery` and wraps it in a `SubqueryRef`. This is the identical technique DuckDB's own built-in `query(sql)` table function uses (`duckdb/src/function/table/query_function.cpp`) — it's what gives `execute_sparql(...)` genuine single-query-plan treatment (filter/projection pushdown, join reordering, cardinality estimation on the real underlying plan) instead of running the translated SQL as an opaque nested execution the way `ClientContextSQLConnection` does for full-R2RML `COPY` (see below). Column-alias handling (`AS t(a, b)`) is done by the binder before it calls into `Bind()`, so no extra code is needed for it. `bind_replace`-only table functions register with `nullptr` for both the `function`/`bind` constructor arguments.
+
 ### Prefix Introspection
 
 `src/read_rdf_prefixes.cpp` implements `read_rdf_prefixes`, returning `prefix`, `uri`, `is_base` (+ optional `filename`) rows from Turtle/TriG files. It errors for NTriples/NQuads/RDF-XML, which have no prefix declarations.
@@ -184,6 +189,6 @@ SELECT COUNT(*) FROM read_rdf('path/to/file.nt');
 ```
 
 Conventions:
-- Every feature area has its own `.test` file (e.g. `filter_pushdown.test`, `projection_pushdown.test`, `read_rdf_parallel_ranges.test`, `gz_compression.test`, `zst_compression.test`, `pivot_rdf.test`, `write_rdf.test`, `sparql_to_sql.test`). Add new tests alongside the feature they cover.
+- Every feature area has its own `.test` file (e.g. `filter_pushdown.test`, `projection_pushdown.test`, `read_rdf_parallel_ranges.test`, `gz_compression.test`, `zst_compression.test`, `pivot_rdf.test`, `write_rdf.test`, `sparql_to_sql.test`, `execute_sparql.test`). Add new tests alongside the feature they cover.
 - The `read_sparql` tests (`test/sql/read_sparql*.test`) require internet access and may be skipped in CI.
 - The WASM smoke test (`test/wasm-smoke-test/`) is a separate Node.js harness, not run by `make test`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(EXTENSION_SOURCES
     src/rdf_extension.cpp
     src/r2rml_copy.cpp
     src/sparql_to_sql.cpp
+    src/execute_sparql.cpp
     src/serd_buffer.cpp
     src/serd_range_buffer.cpp
     src/rdf_profiler.cpp

--- a/README.md
+++ b/README.md
@@ -213,6 +213,27 @@ The mapping passed to `sparql_to_sql` must be a **full R2RML mapping** — every
 - Unlike `read_sparql`, `sparql_to_sql` has no libcurl/libxml2 dependency and **is available in the WebAssembly build**.
 - See [`docs/functions.md`](docs/functions.md#sparql_to_sqlsparql-mapping) for the full error-message reference.
 
+### Running it directly: `execute_sparql`
+
+`execute_sparql(sparql, mapping)` is a table function that translates and runs a SPARQL query in one step — no copy-pasting the `sparql_to_sql` output into a second query:
+
+```sql
+SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'mapping.ttl'
+);
+```
+
+It shares `sparql_to_sql`'s translation logic, so it has the same mapping requirements and raises the same errors. What makes it more than a convenience wrapper: it uses DuckDB's `bind_replace` table function mechanism (the same one behind DuckDB's own built-in `query()` table function) to splice the translated SQL into the *calling* query's plan **before optimization** — as a real subquery, not an opaque nested execution. Filters, projections, and joins written around the call get pushed into the same plan DuckDB would build had you pasted the SQL yourself:
+
+```sql
+SELECT t.v_name
+FROM execute_sparql('SELECT ?e ?name WHERE { ?e <http://example.com/ns#name> ?name }', 'mapping.ttl') AS t
+WHERE t.v_e = 'http://data.example.com/employee/7369';
+```
+
+Like `sparql_to_sql`, `execute_sparql` has no libcurl/libxml2 dependency and is available in the WebAssembly build.
+
 ## _Experimental_ RDF write support
 
 The extension can also write RDF from DuckDB data using an [R2RML](https://www.w3.org/TR/r2rml/) or [YARRML](https://rml.io/yarrrml/) mapping file, DuckDB's `COPY TO` syntax and the [SQL2RDF++](https://github.com/nonodename/sql2rdf) library. Two modes are supported, and the correct one is chosen automatically based on the mapping.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ LOAD rdf;
 ```
 That's it! The extension is now ready to use.
 
+## Quick start
+```
+-- Read multiple files with a glob pattern
+SELECT COUNT(*) FROM read_rdf('shards/*.nt');
+```
 Full documentation for all the functions can be found in [docs/functions.md](docs/functions.md).
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# A DuckDB extension to work with RDF
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+![GitHub Release](https://img.shields.io/github/v/release/nonodename/duck_rdf)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/nonodename/duck_rdf/.github%2Fworkflows%2FMainDistributionPipeline.yml)
+[![DuckDB](https://img.shields.io/static/v1?label=duckdb&message=v1.5.4%2B&color=blue)](https://github.com/duckdb/duckdb/releases)
+[![Community downloads per week](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcommunity-extensions.duckdb.org%2Fdownloads-last-week.json&query=%24.rdf&label=downloads%2Fweek&color=brightgreen)](https://duckdb.org/community_extensions/download_metrics)
 
+![Duck RDF Logo](docs/logo.svg)
+# A DuckDB extension to work with RDF
 Read, write and manipulate RDF within DuckDB. This extension has three broad capabilities
 * reading/profiling RDF from standard serializations, [Turtle](http://www.w3.org/TR/turtle/), [NTriples](http://www.w3.org/TR/n-triples/), [NQuads](http://www.w3.org/TR/n-quads/), [TriG](http://www.w3.org/TR/trig/), and [RDF/XML](https://www.w3.org/TR/rdf12-xml/) into a standard columnar schema or pivoted based on observed predicates.
 * writing using [R2RML](https://www.w3.org/TR/r2rml/) or [YARRML](https://rml.io/yarrrml/) mappings

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# A DuckDB extension to read and write RDF
+# A DuckDB extension to work with RDF
 
-This extension, Rdf, allow you to read & write RDF files directly in to/out of DuckDB. The [SERD](https://drobilla.gitlab.io/serd/doc/singlehtml/) libray is used for this, meaning the extension can parse/write [Turtle](http://www.w3.org/TR/turtle/), [NTriples](http://www.w3.org/TR/n-triples/), [NQuads](http://www.w3.org/TR/n-quads/), and [TriG](http://www.w3.org/TR/trig/). An experimental parser is also provideded to read RDF/XML serialization. This is used when the file extension is `.rdf` or `.xml`. No XML write is supported. No one needs that.
+Read, write and manipulate RDF within DuckDB. This extension has three broad capabilities
+* reading/profiling RDF from standard serializations, [Turtle](http://www.w3.org/TR/turtle/), [NTriples](http://www.w3.org/TR/n-triples/), [NQuads](http://www.w3.org/TR/n-quads/), [TriG](http://www.w3.org/TR/trig/), and [RDF/XML](https://www.w3.org/TR/rdf12-xml/) into a standard columnar schema or pivoted based on observed predicates.
+* writing using [R2RML](https://www.w3.org/TR/r2rml/) or [YARRML](https://rml.io/yarrrml/) mappings
+* querying either remote sources or using a subset of [SPARQL](https://www.w3.org/TR/sparql11-query/) and the R2RML/Yarrrml mappings in reverse
 
-> **WebAssembly (duckdb-wasm) support:** The WASM build supports Turtle, NTriples, NQuads, and TriG on local files. RDF/XML parsing and `read_sparql()` (which requires OS-level networking via libcurl) are not available in WASM. Attempting to use them will raise a clear error.
+The extension works across all platforms that DuckDB supports however, note that RDF/XML parsing and `read_sparql()` (which requires OS-level networking via libcurl) are not available in WASM. 
 
-Gzip and Zst compression is supported (for example `.nt.gz`) but note that zst compression requires the parquet library to be installed and loaded to add that support.
+Gzip and Zst compression are supported for reads (for example `.nt.gz`). Zst compression requires the parquet library to be installed and loaded prior to invocation.
 
 ## Installation
 
@@ -17,301 +20,13 @@ LOAD rdf;
 ```
 That's it! The extension is now ready to use.
 
-## Reading RDF
-
-Six columns are returned for RDF. Three are always not null:
-* subject
-* predicate
-* object
-
-The other three columns will be null if no value is provided in the underlying RDF file:
-* graph
-* language_tag
-* datatype
-
-An optional seventh columnn is available to return the filename that the triple was found in.
-
-
- `read_rdf()` takes a file path, glob pattern, or `LIST` of paths/globs and returns a table. When multiple files are matched, all of them are read and their triples are combined:
-```
-D select subject, predicate from read_rdf('test/rdf/tests.nt');
-┌───────────────────────────────────┬─────────────────────────────────────────────────┐
-│              subject              │                    predicate                    │
-│              varchar              │                     varchar                     │
-├───────────────────────────────────┼─────────────────────────────────────────────────┤
-│ http://example.org/person/JohnDoe │ http://www.w3.org/1999/02/22-rdf-syntax-ns#type │
-│ http://example.org/person/JohnDoe │ http://xmlns.com/foaf/0.1/name                  │
-│ http://example.org/person/JohnDoe │ http://xmlns.com/foaf/0.1/age                   │
-│ http://example.org/person/JohnDoe │ http://xmlns.com/foaf/0.1/knows                 │
-│ jane                              │ http://www.w3.org/1999/02/22-rdf-syntax-ns#type │
-│ jane                              │ http://xmlns.com/foaf/0.1/name                  │
-│ http://example.org/book/123       │ http://purl.org/dc/elements/1.1/title           │
-│ http://example.org/book/123       │ http://purl.org/dc/elements/1.1/creator         │
-│ http://unicode.org/duck           │ http://example.org/hasEmoji                     │
-└───────────────────────────────────┴─────────────────────────────────────────────────┘
-```
-### Optional Parameters
-
-#### Strict Parsing
-
-The optional parameter `strict_parsing`, defaults to true and exposes the underlying strict parsing feature of the serd RDF parsing library. When false it permits malformed URIs. To disable strict parsing, pass `strict_parsing = false`.
-
-#### Prefix Expansion
-
-The optional parameter `prefix_expansion` defaults to false and exposes the underlying serd `serd_env_expand_node` function to expand [CURIE](https://en.wikipedia.org/wiki/CURIE) form URIs to fully defined URIs. This is applied to all columns and is ignored when parsing ntriples and nquads.
-
-#### File Type override
-
-The optional parameter `file_type` can be used to override the detected file type of the file. The following values are recognized:
- * Turtle: `ttl`, `turtle`
- * NQuads: `nq`, `nquads`
- * NTriples: `nt`, `ntriples`
- * Trig: `trig`
- * RDF/XML `rdf`, `xml`
-
-When using a glob pattern the `file_type` override is applied uniformly to every matched file.
-
-### Filename column
-
-The parameter `filename`, a boolean, defaults to `false`. When `true`, adds a 7th column `filename` containing the source file path for each triple.
-
-### Glob / multiple files
-
-The path argument accepts a glob pattern or a `LIST` of paths/glob patterns, allowing multiple RDF files to be read in a single call. All matched files are scanned in parallel and their triples are combined into one result set:
-
-```sql
--- Read all NTriples files in a directory
-SELECT COUNT(*) FROM read_rdf('data/shards/*.nt');
-
--- Mix with other parameters — file_type applies to every matched file
-SELECT * FROM read_rdf('data/shards/*.dat', file_type = 'ttl', strict_parsing = false);
-
--- A LIST of explicit paths and/or glob patterns is also accepted
-SELECT COUNT(*) FROM read_rdf(['data/shards/a.nt', 'data/shards/b.nt']);
-```
-
-If the pattern (or list) matches no files an `IO Error` is raised.
-
-## Reading RDF Prefixes
-
-`read_rdf_prefixes()` returns the `@prefix` and `@base` declarations from Turtle or TriG files. It is useful for namespace introspection, documentation, and building CURIE-aware tooling. NTriples, RDF/XML & NQuads are not supported (they have no prefix declarations) and will raise an error.
-
-```sql
-SELECT prefix, uri, is_base FROM read_rdf_prefixes('test/rdf/tests.ttl');
-```
-
-```
-┌────────┬───────────────────────────────┬─────────┐
-│ prefix │              uri              │ is_base │
-│varchar │            varchar            │ boolean │
-├────────┼───────────────────────────────┼─────────┤
-│ foaf   │ http://xmlns.com/foaf/0.1/    │ false   │
-│ dc     │ http://purl.org/dc/elements/… │ false   │
-│        │ http://example.org/           │ true    │
-│ uni    │ http://unicode.org/           │ false   │
-└────────┴───────────────────────────────┴─────────┘
-```
-
-`read_rdf_prefixes()` accepts the same `strict_parsing`, `file_type`, and `filename` parameters as `read_rdf()` and supports glob patterns and `LIST` arguments:
-
-```sql
--- Collect all unique prefixes across a set of Turtle files
-SELECT DISTINCT prefix, uri
-FROM read_rdf_prefixes('ontologies/*.ttl')
-ORDER BY prefix;
-```
-
-## Pivoting RDF
-
-`pivot_rdf()` takes the same path/glob argument as `read_rdf()` and returns a pivoted table, one column per predicate, at least one row per subject. (To operate on arbitrary file sizes subjects _may_ be repeated if encountered out of sequence). While a pivot is possible in the SQL domain, it is subject to memory limits which this function aims to avoid by doing two passes on the RDF.
-
-```sql
-SELECT graph, subject, "http://example.org/hasEmoji" FROM pivot_rdf('test/rdf/tests.trig', prefix_expansion=true);
-```
-
-```
-┌──────────┬───────────────────────────────────┬─────────────────────────────┐
-│  graph   │              subject              │ http://example.org/hasEmoji │
-│ varchar  │              varchar              │           varchar           │
-├──────────┼───────────────────────────────────┼─────────────────────────────┤
-│ read_rdf │ http://example.org/book/123       │ NULL                        │
-│ read_rdf │ http://unicode.org/duck           │ 🦆                          │
-│ read_rdf │ jane                              │ NULL                        │
-│ read_rdf │ http://example.org/person/JohnDoe │ NULL                        │
-└──────────┴───────────────────────────────────┴─────────────────────────────┘
-```
-
-`profile_rdf` accepts the same `strict_parsing` and `file_type` parameters as `read_rdf`, and supports glob patterns and `LIST` arguments across all supported formats.
-
-
-## Querying SPARQL Endpoints
-
-The experimental `read_sparql(endpoint, query)` sends a SPARQL SELECT query to a remote endpoint and returns the result set as a DuckDB table. Column names are derived from the SPARQL variable names; all columns are VARCHAR. Unbound variables are returned as empty strings.
-
-Only non authenticated SPARQL end points are supported at this time, but a future version could use  `ATTACH` and secrets to bind more complex end points.
-
-```sql
--- Simple value lookup — returns one row with column "x"
-SELECT x FROM read_sparql(
-    'https://query.wikidata.org/sparql',
-    'SELECT ?x WHERE { VALUES ?x { "hello" } }'
-);
-```
-
-```
-┌─────────┐
-│    x    │
-│ varchar │
-├─────────┤
-│ hello   │
-└─────────┘
-```
-
-```sql
--- Count number of humans in wikidata
-SELECT * FROM read_sparql(
-             'https://query.wikidata.org/sparql',
-             'SELECT (COUNT(*) AS ?count) WHERE {   ?item wdt:P31 wd:Q5 .}'
-         );
-```
-
-```
-┌──────────┐
-│  count   │
-│ varchar  │
-├──────────┤
-│ 13074374 │
-└──────────┘
-``` 
-
-**Notes:**
-- Only anonymous (unauthenticated) endpoints are supported.
-- The entire result set is fetched at query-planning time; very large result sets will consume significant memory.
-- Both HTTP and HTTPS endpoints are supported.
-- `read_sparql` is not available in the WebAssembly build (requires libcurl).
-
-## SPARQL-to-SQL translation
-
-`sparql_to_sql(sparql, mapping)` translates a SPARQL `SELECT`/`ASK` query into an equivalent standalone SQL query, using an R2RML or YARRML mapping file "in reverse" via the [SQL2RDF++](https://github.com/nonodename/sql2rdf) `sparql2sql` translator. This is the opposite direction from `read_sparql`: instead of sending SPARQL to a remote endpoint, it compiles SPARQL into SQL you run yourself against the mapped DuckDB tables.
-
-```sql
--- Same mapping/table shape as the R2RML write example below
-CREATE TABLE emp AS SELECT 7369 AS empno, 'SMITH' AS ename, 10 AS deptno;
-
-SELECT sparql_to_sql(
-    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
-    'mapping.ttl'
-) AS sql;
-```
-
-The mapping passed to `sparql_to_sql` must be a **full R2RML mapping** — every `TriplesMap` needs an `rr:logicalTable` (or YARRRML `sources`) naming the table/view to query, i.e. `is_valid_r2rml(mapping)` must be `true`. Inside-out-only mappings (`can_call_inside_out(mapping) = true` but `is_valid_r2rml(mapping) = false`) aren't accepted, since there's no live SQL connection for the translator to bounce rows through.
-
-**Notes:**
-- Only the `duckdb` SQL dialect is currently supported.
-- Only `SELECT` and `ASK` SPARQL query forms are supported; `CONSTRUCT`/`DESCRIBE` raise an error.
-- `GRAPH`, `SERVICE`, most property paths, and some `FILTER` builtins aren't supported yet and raise a detailed error naming the unsupported construct.
-- Unlike `read_sparql`, `sparql_to_sql` has no libcurl/libxml2 dependency and **is available in the WebAssembly build**.
-- See [`docs/functions.md`](docs/functions.md#sparql_to_sqlsparql-mapping) for the full error-message reference.
-
-### Running it directly: `execute_sparql`
-
-`execute_sparql(sparql, mapping)` is a table function that translates and runs a SPARQL query in one step — no copy-pasting the `sparql_to_sql` output into a second query:
-
-```sql
-SELECT * FROM execute_sparql(
-    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
-    'mapping.ttl'
-);
-```
-
-It shares `sparql_to_sql`'s translation logic, so it has the same mapping requirements and raises the same errors. What makes it more than a convenience wrapper: it uses DuckDB's `bind_replace` table function mechanism (the same one behind DuckDB's own built-in `query()` table function) to splice the translated SQL into the *calling* query's plan **before optimization** — as a real subquery, not an opaque nested execution. Filters, projections, and joins written around the call get pushed into the same plan DuckDB would build had you pasted the SQL yourself:
-
-```sql
-SELECT t.v_name
-FROM execute_sparql('SELECT ?e ?name WHERE { ?e <http://example.com/ns#name> ?name }', 'mapping.ttl') AS t
-WHERE t.v_e = 'http://data.example.com/employee/7369';
-```
-
-Like `sparql_to_sql`, `execute_sparql` has no libcurl/libxml2 dependency and is available in the WebAssembly build.
-
-## _Experimental_ RDF write support
-
-The extension can also write RDF from DuckDB data using an [R2RML](https://www.w3.org/TR/r2rml/) or [YARRML](https://rml.io/yarrrml/) mapping file, DuckDB's `COPY TO` syntax and the [SQL2RDF++](https://github.com/nonodename/sql2rdf) library. Two modes are supported, and the correct one is chosen automatically based on the mapping.
-
-This write support is **experimental**! It passes the tests but the author doesn't have any production scaled out workload to try this on. If you use it and find issues, please get in touch and contribute issues using [contributing](CONTRIBUTING.md) guidance.
-
-### Inside-out mode
-
-Use this when your R2RML mapping has **no** `rr:logicalTable` declarations (i.e. `can_call_inside_out()` returns `true`). DuckDB drives the SQL query and passes each result row to the extension, which maps them to RDF triples using the mapping:
-
-```sql
-COPY (SELECT empno, ename, deptno FROM emp)
-TO 'output.nt'
-(FORMAT r2rml, mapping 'mapping.ttl');
-```
-
-This mode uses DuckDBs parallelism for ntriples so expect writes to be very fast.
-
-### Full R2RML mode
-
-Use this when your mapping has `rr:logicalTable` declarations that specify which tables to query. The extension ignores the SQL in the `COPY` statement and runs the mapping's own queries against the live DuckDB instance. Pass a dummy `SELECT 1` to satisfy DuckDB's `COPY` syntax:
-
-```sql
-COPY (SELECT 1) TO 'output.nt' (FORMAT r2rml, mapping 'mapping.ttl');
-```
-
-To be clear, this is a bit of a hack. But it works, under the covers it's a bit ugly. Output does stream so, in principle there should be no limit on output file size, however the write will be single threaded and not benefit from Duck's parallism.
-
-### Options
-
-| Option | Required | Default | Description |
-|--------|----------|---------|-------------|
-| `mapping` | Yes | — | Path to the R2RML mapping file (`.ttl`) |
-| `rdf_format` | No | `ntriples` | Output RDF serialization: `ntriples`, `turtle`, or `nquads` |
-| `ignore_non_fatal_errors` | No | `true` | When `true`, logical parse errors (e.g. unresolved `rr:parentTriplesMap`, unrecognised logical-table type) are collected silently. When `false`, the first such error raises an exception. |
-| `ignore_case` | No | `false` | When `true`, all column and table names are lowercased before matching. Use when your R2RML mapping uses lowercase names — DuckDB folds unquoted identifiers to lowercase, so this is the recommended setting for new mappings. |
-
-### Example
-
-```sql
--- Create some data
-CREATE TABLE emp AS SELECT 7369 AS empno, 'SMITH' AS ename, 10 AS deptno;
-
--- Write as NTriples using an inside-out mapping
-COPY (SELECT empno, ename, deptno FROM emp)
-TO 'employees.nt'
-(FORMAT r2rml, mapping 'mapping.ttl');
-
--- Read it back
-SELECT subject, predicate, object FROM read_rdf('employees.nt');
-```
-
-```
-┌───────────────────────────────────────┬─────────────────────────────────────────────────┬───────────────────────────────────────┐
-│ subject                               │ predicate                                       │ object                                │
-├───────────────────────────────────────┼─────────────────────────────────────────────────┼───────────────────────────────────────┤
-│ http://data.example.com/employee/7369 │ http://example.com/ns#department                │ http://data.example.com/department/10 │
-│ http://data.example.com/employee/7369 │ http://example.com/ns#name                      │ SMITH                                 │
-│ http://data.example.com/employee/7369 │ http://www.w3.org/1999/02/22-rdf-syntax-ns#type │ http://example.com/ns#Employee        │
-└───────────────────────────────────────┴─────────────────────────────────────────────────┴───────────────────────────────────────┘
-```
-
-### R2RML validation helpers
-
-Two scalar functions are available to validate R2RML mapping files:
-
-```sql
--- Returns true if the file is a valid R2RML mapping
-SELECT is_valid_r2rml('mapping.ttl');
-
--- Returns true if the mapping is valid for inside-out mode (no rr:logicalTable etc.) 
--- note we break the YARRML spec a little here by not requiring tables
-SELECT can_call_inside_out('mapping.yml');
-```
+Full documentation for all the functions can be found in [docs/functions.md](docs/functions.md).
 
 ## Building
 ### Managing dependencies
-DuckDB extensions uses VCPKG for dependency management. Enabling VCPKG is very simple: follow the installation instructions or just run the following:
+Where possible VCPKG is used for dependencies. However, libraries like serd are not available on VCPKG, so for these, CMake FetchContent is used instead (e.g. you need an Internet connection at build time.)
+
+Enabling VCPKG is very simple: follow the installation instructions or just run the following:
 
 ```sh
 cd <your-working-dir-not-the-plugin-repo>
@@ -349,6 +64,9 @@ The main binaries that will be built are:
 - `duckdb` is the binary for the duckdb shell with the extension code automatically loaded.
 - `unittest` is the test runner of duckdb. Again, the extension is already linked into the binary.
 - `rdf.duckdb_extension` is the loadable binary as it would be distributed.
+## Cleanliness
+
+Use `make format` to format all code to the DuckDB standards, `make tidy-check` to lint.
 
 ## Running the extension
 To run the extension code, simply start the shell with `./build/release/duckdb`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# A DuckDB extension to work with RDF
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![GitHub Release](https://img.shields.io/github/v/release/nonodename/duck_rdf)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/nonodename/duck_rdf/.github%2Fworkflows%2FMainDistributionPipeline.yml)
@@ -5,9 +7,9 @@
 [![Community downloads per week](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fcommunity-extensions.duckdb.org%2Fdownloads-last-week.json&query=%24.rdf&label=downloads%2Fweek&color=brightgreen)](https://duckdb.org/community_extensions/download_metrics)
 
 ![Duck RDF Logo](docs/logo.svg)
-# A DuckDB extension to work with RDF
+
 Read, write and manipulate RDF within DuckDB. This extension has three broad capabilities
-* reading/profiling RDF from standard serializations, [Turtle](http://www.w3.org/TR/turtle/), [NTriples](http://www.w3.org/TR/n-triples/), [NQuads](http://www.w3.org/TR/n-quads/), [TriG](http://www.w3.org/TR/trig/), and [RDF/XML](https://www.w3.org/TR/rdf12-xml/) into a standard columnar schema or pivoted based on observed predicates.
+* reading/profiling RDF from standard serializations: [Turtle](http://www.w3.org/TR/turtle/), [NTriples](http://www.w3.org/TR/n-triples/), [NQuads](http://www.w3.org/TR/n-quads/), [TriG](http://www.w3.org/TR/trig/), and [RDF/XML](https://www.w3.org/TR/rdf12-xml/) into a standard columnar schema or pivoted based on observed predicates.
 * writing using [R2RML](https://www.w3.org/TR/r2rml/) or [YARRML](https://rml.io/yarrrml/) mappings
 * querying either remote sources or using a subset of [SPARQL](https://www.w3.org/TR/sparql11-query/) and the R2RML/Yarrrml mappings in reverse
 
@@ -30,8 +32,24 @@ That's it! The extension is now ready to use.
 ```
 -- Read multiple files with a glob pattern
 SELECT COUNT(*) FROM read_rdf('shards/*.nt');
+
+-- Execute a Sparql query over DuckDB tables using an R2RML mapping
+memory D CREATE TABLE emp AS SELECT 7369 AS EMPNO, 'SMITH' AS ENAME, 10 AS DEPTNO;
+memory D SELECT * FROM execute_sparql(
+             'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+             'test/r2rml/full_r2rml_lower.ttl'
+         );
+┌───────────────────────────────────────┬─────────┐
+│                  v_e                  │ v_name  │
+│                varchar                │ varchar │
+├───────────────────────────────────────┼─────────┤
+│ http://data.example.com/employee/7369 │ SMITH   │
+└───────────────────────────────────────┴─────────┘
 ```
+Sparql support is _very experimental_ but quite interesting as it uses Duck's query optimizer. Please contribute issues with full steps to reproduce if you find cases that should work but don't. Sparql parsing and conversion to SQL is via the [sql2rdf](https://github.com/nonodename/sql2rdf) library.
+
 Full documentation for all the functions can be found in [docs/functions.md](docs/functions.md).
+
 
 ## Building
 ### Managing dependencies

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1,4 +1,4 @@
-# Function Reference
+# Reading RDF
 
 ## `read_rdf(path, [options])`
 
@@ -65,7 +65,23 @@ FROM read_rdf('data/*.nt', filename = true)
 GROUP BY filename
 ORDER BY filename;
 ```
-
+```
+D select subject, predicate from read_rdf('test/rdf/tests.nt');
+┌───────────────────────────────────┬─────────────────────────────────────────────────┐
+│              subject              │                    predicate                    │
+│              varchar              │                     varchar                     │
+├───────────────────────────────────┼─────────────────────────────────────────────────┤
+│ http://example.org/person/JohnDoe │ http://www.w3.org/1999/02/22-rdf-syntax-ns#type │
+│ http://example.org/person/JohnDoe │ http://xmlns.com/foaf/0.1/name                  │
+│ http://example.org/person/JohnDoe │ http://xmlns.com/foaf/0.1/age                   │
+│ http://example.org/person/JohnDoe │ http://xmlns.com/foaf/0.1/knows                 │
+│ jane                              │ http://www.w3.org/1999/02/22-rdf-syntax-ns#type │
+│ jane                              │ http://xmlns.com/foaf/0.1/name                  │
+│ http://example.org/book/123       │ http://purl.org/dc/elements/1.1/title           │
+│ http://example.org/book/123       │ http://purl.org/dc/elements/1.1/creator         │
+│ http://unicode.org/duck           │ http://example.org/hasEmoji                     │
+└───────────────────────────────────┴─────────────────────────────────────────────────┘
+```
 ---
 
 ## `read_rdf_prefixes(path, [options])`
@@ -128,7 +144,19 @@ FROM read_rdf_prefixes('data/*.ttl', filename = true)
 GROUP BY filename
 ORDER BY prefix_count DESC;
 ```
+```sql
+SELECT prefix, uri, is_base FROM read_rdf_prefixes('test/rdf/tests.ttl');
 
+┌────────┬───────────────────────────────┬─────────┐
+│ prefix │              uri              │ is_base │
+│varchar │            varchar            │ boolean │
+├────────┼───────────────────────────────┼─────────┤
+│ foaf   │ http://xmlns.com/foaf/0.1/    │ false   │
+│ dc     │ http://purl.org/dc/elements/… │ false   │
+│        │ http://example.org/           │ true    │
+│ uni    │ http://unicode.org/           │ false   │
+└────────┴───────────────────────────────┴─────────┘
+```
 ---
 
 ## `profile_rdf(path, [options])`
@@ -235,9 +263,26 @@ SELECT * FROM pivot_rdf('test/rdf/tests.trig', prefix_expansion=true);
 -- Read an explicit list of files
 SELECT * FROM pivot_rdf(['a.ttl', 'b.ttl']);
 ```
+```sql
+SELECT graph, subject, "http://example.org/hasEmoji" FROM pivot_rdf('test/rdf/tests.trig', prefix_expansion=true);
+```
+
+```
+┌──────────┬───────────────────────────────────┬─────────────────────────────┐
+│  graph   │              subject              │ http://example.org/hasEmoji │
+│ varchar  │              varchar              │           varchar           │
+├──────────┼───────────────────────────────────┼─────────────────────────────┤
+│ read_rdf │ http://example.org/book/123       │ NULL                        │
+│ read_rdf │ http://unicode.org/duck           │ 🦆                          │
+│ read_rdf │ jane                              │ NULL                        │
+│ read_rdf │ http://example.org/person/JohnDoe │ NULL                        │
+└──────────┴───────────────────────────────────┴─────────────────────────────┘
+```
+
 **Limitations**
 Subjects that repeat across multiple files will appear as multiple rows in the resulting table. To do otherwise would greatly impact performance. In the same way, triples or quads that *exactly* duplicate within a file will be deduped but not across files.
 ---
+# Querying RDF
 
 ## `read_sparql(endpoint, query)`
 
@@ -286,7 +331,22 @@ SELECT COUNT(*) FROM read_sparql(
   'SELECT ?item WHERE { ?item wdt:P31 wd:Q5 } LIMIT 100'
 );
 ```
+```sql
+-- Count number of humans in wikidata
+SELECT * FROM read_sparql(
+             'https://query.wikidata.org/sparql',
+             'SELECT (COUNT(*) AS ?count) WHERE {   ?item wdt:P31 wd:Q5 .}'
+         );
+```
 
+```
+┌──────────┐
+│  count   │
+│ varchar  │
+├──────────┤
+│ 13074374 │
+└──────────┘
+``` 
 ---
 
 ## `is_valid_r2rml(path)`
@@ -363,19 +423,24 @@ On failure, `sparql_to_sql` raises an error whose message identifies which stage
 **Example**
 
 ```sql
+-- Same mapping/table shape as the R2RML write example below
+CREATE TABLE emp AS SELECT 7369 AS empno, 'SMITH' AS ename, 10 AS deptno;
+
 SELECT sparql_to_sql(
     'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
     'mapping.ttl'
-);
+) AS sql;
 ```
-
 ---
+# Querying RDF
 
 ## `execute_sparql(sparql, mapping)`
 
 Table function. Translates a SPARQL `SELECT` or `ASK` query into SQL exactly like `sparql_to_sql` (same mapping, same translator), then runs that SQL directly instead of returning it as a string.
 
 Unlike calling `sparql_to_sql()` and pasting the result into a second query, `execute_sparql(...)` splices the translated SQL into *this* query's own plan before optimization — it uses DuckDB's `bind_replace` table function mechanism (the same one behind the built-in `query()` table function) to substitute a real subquery for the function call at bind time. Filters, projections, and joins written around the call are planned and optimized together with the translated SQL, exactly as if you had written the SQL yourself inline. There is no intermediate opaque "run this and stream the rows back" step.
+
+Like `sparql_to_sql`, `execute_sparql` has no libcurl/libxml2 dependency and is available in the WebAssembly build.
 
 **Parameters**
 
@@ -416,6 +481,7 @@ WHERE t.v_e = 'http://data.example.com/employee/7369';
 
 ---
 
+# Writing RDF
 ## `COPY ... TO ... (FORMAT r2rml, ...)`
 
 Copy function. Writes RDF from a DuckDB query using an R2RML or YARRML mapping.
@@ -439,23 +505,29 @@ TO 'output.nt'
 (FORMAT r2rml, mapping 'mapping.ttl');
 ```
 
-This mode benefits from DuckDB parellism. 
+This mode benefits from DuckDB parellism and will have substantial performance gains for large volumes of nTriples (which can be written by multiple threads).
 
 **Full R2RML mode** — use when the mapping contains `rr:logicalTable` declarations. The extension ignores the `COPY` query and runs its own queries from the mapping. Pass a dummy `SELECT 1`:
 
 ```sql
-COPY (SELECT 1)
-TO 'output.nt'
-(FORMAT r2rml, mapping 'mapping.ttl');
-```
-This mode will be single threaded and less performant than the equivalent inside out.
-
-**Example**
-
-```sql
+-- Create some data
 CREATE TABLE emp AS SELECT 7369 AS empno, 'SMITH' AS ename, 10 AS deptno;
 
+-- Write as NTriples using an inside-out mapping
 COPY (SELECT empno, ename, deptno FROM emp)
 TO 'employees.nt'
-(FORMAT r2rml, mapping 'mapping.ttl', rdf_format 'turtle');
+(FORMAT r2rml, mapping 'mapping.ttl');
+
+-- Read it back
+SELECT subject, predicate, object FROM read_rdf('employees.nt');
+```
+
+```
+┌───────────────────────────────────────┬─────────────────────────────────────────────────┬───────────────────────────────────────┐
+│ subject                               │ predicate                                       │ object                                │
+├───────────────────────────────────────┼─────────────────────────────────────────────────┼───────────────────────────────────────┤
+│ http://data.example.com/employee/7369 │ http://example.com/ns#department                │ http://data.example.com/department/10 │
+│ http://data.example.com/employee/7369 │ http://example.com/ns#name                      │ SMITH                                 │
+│ http://data.example.com/employee/7369 │ http://www.w3.org/1999/02/22-rdf-syntax-ns#type │ http://example.com/ns#Employee        │
+└───────────────────────────────────────┴─────────────────────────────────────────────────┴───────────────────────────────────────┘
 ```

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -371,6 +371,51 @@ SELECT sparql_to_sql(
 
 ---
 
+## `execute_sparql(sparql, mapping)`
+
+Table function. Translates a SPARQL `SELECT` or `ASK` query into SQL exactly like `sparql_to_sql` (same mapping, same translator), then runs that SQL directly instead of returning it as a string.
+
+Unlike calling `sparql_to_sql()` and pasting the result into a second query, `execute_sparql(...)` splices the translated SQL into *this* query's own plan before optimization — it uses DuckDB's `bind_replace` table function mechanism (the same one behind the built-in `query()` table function) to substitute a real subquery for the function call at bind time. Filters, projections, and joins written around the call are planned and optimized together with the translated SQL, exactly as if you had written the SQL yourself inline. There is no intermediate opaque "run this and stream the rows back" step.
+
+**Parameters**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sparql` | VARCHAR | The SPARQL query text |
+| `mapping` | VARCHAR | Path to the R2RML or YARRML mapping file |
+
+**Returns**
+
+A table whose schema is whatever the translated SQL produces: one column per SPARQL SELECT variable (named `v_<variable>`), holding the VARCHAR lexical form of each bound RDF term — the same shape you'd get from running `sparql_to_sql`'s output SQL yourself.
+
+**Requirements**
+
+Identical to `sparql_to_sql` (they share the same translation code):
+
+- The mapping must be a **full R2RML mapping**: every `TriplesMap` needs an `rr:logicalTable` (or, for YARRRML, a `sources` entry) naming the table or view to query — the same requirement `is_valid_r2rml()` checks. An inside-out-only mapping is **not** sufficient here.
+- Only the `SELECT` and `ASK` SPARQL query forms are supported. `CONSTRUCT` and `DESCRIBE` raise an error naming the unsupported form.
+- `GRAPH`, `SERVICE`, most property paths, and a handful of `FILTER` builtins are not yet supported and raise a detailed error describing the unsupported construct.
+
+**Errors**
+
+Raises the exact same errors as `sparql_to_sql` (see its table above), since both go through the same translation helper.
+
+**Example**
+
+```sql
+SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'mapping.ttl'
+);
+
+-- Filters/joins around the call are planned together with the translated SQL
+SELECT t.v_name
+FROM execute_sparql('SELECT ?e ?name WHERE { ?e <http://example.com/ns#name> ?name }', 'mapping.ttl') AS t
+WHERE t.v_e = 'http://data.example.com/employee/7369';
+```
+
+---
+
 ## `COPY ... TO ... (FORMAT r2rml, ...)`
 
 Copy function. Writes RDF from a DuckDB query using an R2RML or YARRML mapping.

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,548 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="300mm"
+   height="300mm"
+   viewBox="0 0 300 300"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4.4 (dcaf3e7, 2026-05-05)"
+   sodipodi:docname="logo.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title51">Duck RDF Logo</title>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.73"
+     inkscape:cx="487.67123"
+     inkscape:cy="523.28767"
+     inkscape:window-width="1746"
+     inkscape:window-height="1201"
+     inkscape:window-x="755"
+     inkscape:window-y="56"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect6"
+       is_visible="true"
+       lpeversion="1" />
+  </defs>
+  <g
+     id="g11"
+     inkscape:label="subjectDuck"
+     transform="translate(-26.458333,43.855594)">
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 161.05072,158.22711 c 0,0 3.64426,-2.32126 3.8694,-4.81061 0.22514,-2.48935 -4.18313,-5.64723 -4.18313,-5.64723 0,0 4.83592,-2.80944 10.66699,2.61446 2.90287,4.37812 -1.77783,8.99374 -1.77783,8.99374 0,0 2.55675,-0.17341 4.18314,-2.61446 2.9859,1.95119 -3.86941,5.01976 -3.86941,5.01976 0,0 2.80956,-0.80481 4.39229,0.10457 -5.38421,3.90994 -9.37355,3.0895 -8.99373,2.82363 z"
+       id="path9"
+       sodipodi:nodetypes="czcccccccc"
+       inkscape:label="tail" />
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       d="m 103.75234,136.45366 c 0,0 -0.86503,0.6051 -5.499767,7.7294 -4.63473,7.1243 -22.020529,12.00369 -23.931412,23.33684 -1.910883,11.33314 -1.231697,27.5026 44.146769,27.79612 45.37847,0.29351 50.4654,-23.42526 46.32176,-33.51562 -4.14364,-10.09037 -33.39014,-6.87418 -41.11928,-12.41486 -7.72914,-5.54068 -4.16198,-13.37781 -4.16198,-13.37781 z"
+       id="path4"
+       sodipodi:nodetypes="czzzzzcc"
+       inkscape:label="body" />
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       d="M 83.994707,105.41335 C 81.254319,90.315858 95.5218,65.294236 122.63227,70.555556 c 5.52367,1.071976 9.23015,-2.782028 12.22671,-2.208782 1.46386,0.28004 -2.11817,4.310718 -0.83858,4.188034 3.14833,-0.301858 4.62152,-3.374149 5.92581,-2.842207 2.46671,1.006021 -3.15142,5.229714 -1.64066,6.593901 11.82665,10.679207 6.79531,33.746568 6.79531,33.746568 0,0 8.34354,0.44091 7.27404,13.59488 -1.06951,13.15397 -22.40092,15.62314 -47.13613,14.97983 -24.735208,-0.6433 -33.905352,-8.70572 -33.597891,-17.82764 0.307461,-9.12191 5.769859,-9.73285 12.353828,-15.36679 z"
+       id="path3"
+       inkscape:label="head"
+       sodipodi:nodetypes="csssscczzzc" />
+    <g
+       id="g1"
+       inkscape:label="left-eye"
+       transform="matrix(0.62866294,0.09751469,-0.10741108,0.74402699,42.717876,20.671645)">
+      <ellipse
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.23615;stroke-dasharray:none;stroke-opacity:1"
+         id="path1-3"
+         cx="99.001656"
+         cy="97.83477"
+         rx="10.769123"
+         ry="13.991612" />
+      <ellipse
+         style="fill:#000000;stroke-width:0.264583"
+         id="path1"
+         cx="100.40598"
+         cy="100.06677"
+         rx="9.1586533"
+         ry="12.211538" />
+      <ellipse
+         style="fill:#ffffff;stroke:none;stroke-width:0.0702519"
+         id="path1-7-2-5"
+         cx="109.07626"
+         cy="88.586685"
+         rx="2.4451616"
+         ry="3.2246766"
+         transform="matrix(1.5713685,-0.05067507,-0.04433557,1.3301121,-71.105089,-18.464188)" />
+    </g>
+    <g
+       id="g1-2"
+       transform="matrix(0.63267818,0.09050374,-0.10756674,0.76347534,71.577528,20.169568)"
+       inkscape:label="right-eye">
+      <ellipse
+         style="fill:#ffffff;stroke:#000000;stroke-width:1.23615;stroke-dasharray:none;stroke-opacity:1"
+         id="path1-3-0"
+         cx="99.001656"
+         cy="97.83477"
+         rx="10.769123"
+         ry="13.991612" />
+      <ellipse
+         style="fill:#000000;stroke-width:0.264583"
+         id="path1-7"
+         cx="100.40598"
+         cy="100.06677"
+         rx="9.1586533"
+         ry="12.211538" />
+      <ellipse
+         style="fill:#ffffff;stroke:none;stroke-width:0.0702519"
+         id="path1-7-2"
+         cx="137.85942"
+         cy="85.841255"
+         rx="2.4451616"
+         ry="3.2246766"
+         transform="matrix(1.5642008,-0.03410473,-0.04945366,1.2964292,-115.30191,-12.750004)" />
+    </g>
+    <g
+       id="g10"
+       inkscape:label="wing">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 117.13015,155.03394 c 0,0 -14.64227,7.87572 -8.17533,21.10721 6.46695,13.2315 34.39471,5.30369 36.8633,3.1215 2.4686,-2.18219 -0.14864,-3.71606 -0.14864,-3.71606"
+         id="path5"
+         sodipodi:nodetypes="czzc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 141.50749,176.43844 c 2.31332,0.16738 13.01486,-4.42879 13.97238,-8.17533 0.95752,-3.74654 -3.27013,-3.56741 -3.27013,-3.56741"
+         id="path6"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 150.15612,164.65093 c 3.05653,0.6133 13.01487,-4.42879 5.9457,-6.39162 -7.06917,-1.96284 -21.70178,-1.04049 -21.70178,-1.04049"
+         id="path6-7"
+         sodipodi:nodetypes="czc" />
+    </g>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 92.455522,86.955757 c 0,0 5.176806,-2.331563 7.133926,-2.306789 1.957132,0.02477 4.608822,2.455432 4.608822,2.455432"
+       id="path7"
+       sodipodi:nodetypes="czc"
+       inkscape:label="left-brow" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 121.44079,87.996253 c 0,0 4.2275,-2.113163 6.09031,-2.083138 1.86282,0.03002 4.76057,2.380424 4.76057,2.380424"
+       id="path8"
+       sodipodi:nodetypes="czc"
+       inkscape:label="brow" />
+    <g
+       id="g8"
+       inkscape:label="beak"
+       transform="translate(-4.9051967,-2.824204)">
+      <path
+         style="fill:#ff7f2a;fill-opacity:1;stroke:#000000;stroke-width:0.665;stroke-dasharray:none;stroke-opacity:1"
+         d="m 94.413826,121.48851 c 1.75644,-1.07833 6.886274,-4.09788 10.164214,-7.65227 4.41226,-4.78436 5.05284,-7.61411 9.23152,-7.47604 4.17868,0.13807 3.81504,7.21296 5.91873,9.8659 2.10369,2.65294 8.46467,1.63456 4.9427,8.14651 -3.52198,6.51195 -8.09387,7.43378 -13.88908,8.0432 -5.79521,0.60942 -12.10693,-0.005 -16.54413,-0.88441 -4.437203,-0.87915 -8.648399,1.92835 -11.261064,0.0971 -2.612665,-1.83126 -2.972301,-2.81368 -2.972301,-2.81368 0,0 -2.254669,1.13521 -6.050376,0.42807 -3.34628,-0.62341 -5.70921,-2.9404 -5.727395,-4.98898 -0.04019,-4.52742 6.421599,-7.79125 10.786824,-7.64046 4.365225,0.15079 8.829595,3.68363 15.251716,4.72643 z"
+         id="path2"
+         sodipodi:nodetypes="cszzzzzzcsszcc"
+         inkscape:label="break" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 76.840517,127.56115 c 0,0 6.105958,-1.50986 9.955014,-1.48856 3.849056,0.0213 9.340937,2.79518 14.873329,2.91521 7.65548,0.16609 17.38607,-6.03456 17.38607,-6.03456"
+         id="path8-5"
+         sodipodi:nodetypes="czsc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 94.280399,121.60227 c 5.666081,1.94432 7.015801,0.71831 12.045111,2.02122"
+         id="path8-5-5"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 104.87115,116.69612 c 1.01227,-1.28957 -0.018,-0.0178 1.21733,-1.22203"
+         id="path8-3"
+         sodipodi:nodetypes="cc"
+         inkscape:label="nostril"
+         transform="translate(4.9051967,2.824204)" />
+    </g>
+    <g
+       id="g9"
+       inkscape:label="feathers">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 118.75929,175.19485 c 0,0 5.11935,1.00836 7.72538,-0.15078 2.60603,-1.15914 1.63908,-3.26799 1.63908,-3.26799"
+         id="path8-7"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 127.64694,171.94532 c 0,0 3.63293,1.00836 6.23896,-0.15078 2.60603,-1.15914 1.78772,-4.0112 1.78772,-4.0112"
+         id="path8-7-1"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.30387,167.99441 c 0,0 3.63292,1.45429 6.23895,0.29515 2.60603,-1.15914 0.74723,-4.30849 0.74723,-4.30849"
+         id="path8-7-2"
+         sodipodi:nodetypes="czc" />
+    </g>
+    <path
+       style="font-size:25.4px;font-family:'American Typewriter';-inkscape-font-specification:'American Typewriter, Normal';fill:#d40000;stroke-linecap:round"
+       d="m 94.312445,155.20015 q 2.4892,0 3.481575,1.6002 l 0.129427,-0.3556 q 0.360549,-0.9906 1.147952,-0.9906 0.8636,0 0.466072,1.0922 l -0.05547,0.1524 q -0.01849,0.0508 -0.353545,0.762 -0.335056,0.7112 -0.695605,1.7018 -0.04622,0.127 -0.245035,0.8128 l -0.293594,1.016 q -0.02082,0.127 -0.104027,0.3556 -0.443753,1.2192 -1.383553,1.2192 -0.990603,0 -0.620809,-1.016 0.04622,-0.127 0.04622,-0.127 l 0.300411,-0.6858 q 0.154828,-0.3556 0.228786,-0.5588 0.554691,-1.524 -0.172384,-2.3876 -0.701676,-0.8636 -2.505076,-0.8636 -1.651,0 -2.937435,0.8128 -1.261035,0.8128 -1.760256,2.1844 -0.582425,1.6002 0.588029,2.3622 0.664883,0.4064 2.5767,0.7366 2.846948,0.4826 3.659471,1.3208 1.223403,1.2446 0.391367,3.5306 -0.869016,2.3876 -3.141662,3.8862 -2.247248,1.4986 -4.965048,1.4986 -2.8956,0 -4.134972,-1.8288 -0.03698,0.1016 -0.0578,0.2286 -0.04622,0.127 -0.05547,0.1524 -0.09712,0.4064 -0.143342,0.5334 -0.342059,0.9398 -1.231059,0.9398 -0.9652,0 -0.576917,-1.0668 0.04623,-0.127 0.09936,-0.2032 l 0.582332,-1.3208 q 0.436749,-0.9906 0.538442,-1.27 0.184897,-0.508 0.427691,-1.524 0.242794,-1.016 0.42769,-1.524 0.416018,-1.143 1.381218,-1.143 0.9906,0 0.574582,1.143 l -0.166407,0.4572 q -0.09936,0.2032 -0.238031,0.5842 -0.693363,1.905 0.119063,3.0226 0.812427,1.1176 2.895227,1.1176 1.9304,0 3.406215,-0.9144 1.475817,-0.9144 2.048997,-2.4892 0.878261,-2.413 -1.975601,-2.9464 l -1.355351,-0.254 q -2.020328,-0.381 -3.029231,-0.889 -0.916548,-0.4826 -1.207154,-1.4986 -0.255961,-1.0414 0.215526,-2.3368 0.813546,-2.2352 2.947612,-3.6322 2.134067,-1.397 4.724867,-1.397 z"
+       id="text10"
+       inkscape:label="subject"
+       aria-label="S" />
+  </g>
+  <g
+     id="g30"
+     inkscape:label="predicateDuck"
+     transform="translate(42.768266,-15.585045)">
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 161.05072,158.22711 c 0,0 3.64426,-2.32126 3.8694,-4.81061 0.22514,-2.48935 -4.18313,-5.64723 -4.18313,-5.64723 0,0 4.83592,-2.80944 10.66699,2.61446 2.90287,4.37812 -1.77783,8.99374 -1.77783,8.99374 0,0 2.55675,-0.17341 4.18314,-2.61446 2.9859,1.95119 -3.86941,5.01976 -3.86941,5.01976 0,0 2.80956,-0.80481 4.39229,0.10457 -5.38421,3.90994 -9.37355,3.0895 -8.99373,2.82363 z"
+       id="path11"
+       sodipodi:nodetypes="czcccccccc"
+       inkscape:label="tail" />
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       d="m 103.75234,136.45366 c 0,0 -0.86503,0.6051 -5.499767,7.7294 -4.63473,7.1243 -22.020529,12.00369 -23.931412,23.33684 -1.910883,11.33314 -1.231697,27.5026 44.146769,27.79612 45.37847,0.29351 50.4654,-23.42526 46.32176,-33.51562 -4.14364,-10.09037 -33.39014,-6.87418 -41.11928,-12.41486 -7.72914,-5.54068 -4.16198,-13.37781 -4.16198,-13.37781 z"
+       id="path12"
+       sodipodi:nodetypes="czzzzzcc"
+       inkscape:label="body" />
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       d="M 83.994707,105.41335 C 81.254319,90.315858 95.5218,65.294236 122.63227,70.555556 c 5.52367,1.071976 9.23015,-2.782028 12.22671,-2.208782 1.46386,0.28004 -2.11817,4.310718 -0.83858,4.188034 3.14833,-0.301858 4.62152,-3.374149 5.92581,-2.842207 2.46671,1.006021 -3.15142,5.229714 -1.64066,6.593901 11.82665,10.679207 6.79531,33.746568 6.79531,33.746568 0,0 8.34354,0.44091 7.27404,13.59488 -1.06951,13.15397 -22.40092,15.62314 -47.13613,14.97983 -24.735208,-0.6433 -33.905352,-8.70572 -33.597891,-17.82764 0.307461,-9.12191 5.769859,-9.73285 12.353828,-15.36679 z"
+       id="path13"
+       inkscape:label="head"
+       sodipodi:nodetypes="csssscczzzc" />
+    <g
+       id="g15"
+       inkscape:label="left-eye"
+       transform="matrix(0.62866294,0.09751469,-0.10741108,0.74402699,42.717876,20.671645)">
+      <ellipse
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.23615;stroke-dasharray:none;stroke-opacity:1"
+         id="ellipse13"
+         cx="99.001656"
+         cy="97.83477"
+         rx="10.769123"
+         ry="13.991612" />
+      <ellipse
+         style="fill:#000000;stroke-width:0.264583"
+         id="ellipse14"
+         cx="100.40598"
+         cy="100.06677"
+         rx="9.1586533"
+         ry="12.211538" />
+      <ellipse
+         style="fill:#ffffff;stroke:none;stroke-width:0.0702519"
+         id="ellipse15"
+         cx="109.07626"
+         cy="88.586685"
+         rx="2.4451616"
+         ry="3.2246766"
+         transform="matrix(1.5713685,-0.05067507,-0.04433557,1.3301121,-71.105089,-18.464188)" />
+    </g>
+    <g
+       id="g18"
+       transform="matrix(0.63267818,0.09050374,-0.10756674,0.76347534,71.577528,20.169568)"
+       inkscape:label="right-eye">
+      <ellipse
+         style="fill:#ffffff;stroke:#000000;stroke-width:1.23615;stroke-dasharray:none;stroke-opacity:1"
+         id="ellipse16"
+         cx="99.001656"
+         cy="97.83477"
+         rx="10.769123"
+         ry="13.991612" />
+      <ellipse
+         style="fill:#000000;stroke-width:0.264583"
+         id="ellipse17"
+         cx="100.40598"
+         cy="100.06677"
+         rx="9.1586533"
+         ry="12.211538" />
+      <ellipse
+         style="fill:#ffffff;stroke:none;stroke-width:0.0702519"
+         id="ellipse18"
+         cx="137.85942"
+         cy="85.841255"
+         rx="2.4451616"
+         ry="3.2246766"
+         transform="matrix(1.5642008,-0.03410473,-0.04945366,1.2964292,-115.30191,-12.750004)" />
+    </g>
+    <g
+       id="g20"
+       inkscape:label="wing">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 117.13015,155.03394 c 0,0 -14.64227,7.87572 -8.17533,21.10721 6.46695,13.2315 34.39471,5.30369 36.8633,3.1215 2.4686,-2.18219 -0.14864,-3.71606 -0.14864,-3.71606"
+         id="path18"
+         sodipodi:nodetypes="czzc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 141.50749,176.43844 c 2.31332,0.16738 13.01486,-4.42879 13.97238,-8.17533 0.95752,-3.74654 -3.27013,-3.56741 -3.27013,-3.56741"
+         id="path19"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 150.15612,164.65093 c 3.05653,0.6133 13.01487,-4.42879 5.9457,-6.39162 -7.06917,-1.96284 -21.70178,-1.04049 -21.70178,-1.04049"
+         id="path20"
+         sodipodi:nodetypes="czc" />
+    </g>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 92.455522,86.955757 c 0,0 5.176806,-2.331563 7.133926,-2.306789 1.957132,0.02477 4.608822,2.455432 4.608822,2.455432"
+       id="path21"
+       sodipodi:nodetypes="czc"
+       inkscape:label="left-brow" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 121.44079,87.996253 c 0,0 4.2275,-2.113163 6.09031,-2.083138 1.86282,0.03002 4.76057,2.380424 4.76057,2.380424"
+       id="path22"
+       sodipodi:nodetypes="czc"
+       inkscape:label="brow" />
+    <g
+       id="g26"
+       inkscape:label="beak"
+       transform="translate(-4.9051967,-2.824204)">
+      <path
+         style="fill:#ff7f2a;fill-opacity:1;stroke:#000000;stroke-width:0.665;stroke-dasharray:none;stroke-opacity:1"
+         d="m 94.413826,121.48851 c 1.75644,-1.07833 6.886274,-4.09788 10.164214,-7.65227 4.41226,-4.78436 5.05284,-7.61411 9.23152,-7.47604 4.17868,0.13807 3.81504,7.21296 5.91873,9.8659 2.10369,2.65294 8.46467,1.63456 4.9427,8.14651 -3.52198,6.51195 -8.09387,7.43378 -13.88908,8.0432 -5.79521,0.60942 -12.10693,-0.005 -16.54413,-0.88441 -4.437203,-0.87915 -8.648399,1.92835 -11.261064,0.0971 -2.612665,-1.83126 -2.972301,-2.81368 -2.972301,-2.81368 0,0 -2.254669,1.13521 -6.050376,0.42807 -3.34628,-0.62341 -5.70921,-2.9404 -5.727395,-4.98898 -0.04019,-4.52742 6.421599,-7.79125 10.786824,-7.64046 4.365225,0.15079 8.829595,3.68363 15.251716,4.72643 z"
+         id="path23"
+         sodipodi:nodetypes="cszzzzzzcsszcc"
+         inkscape:label="break" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 76.840517,127.56115 c 0,0 6.105958,-1.50986 9.955014,-1.48856 3.849056,0.0213 9.340937,2.79518 14.873329,2.91521 7.65548,0.16609 17.38607,-6.03456 17.38607,-6.03456"
+         id="path24"
+         sodipodi:nodetypes="czsc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 94.280399,121.60227 c 5.666081,1.94432 7.015801,0.71831 12.045111,2.02122"
+         id="path25"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 104.87115,116.69612 c 1.01227,-1.28957 -0.018,-0.0178 1.21733,-1.22203"
+         id="path26"
+         sodipodi:nodetypes="cc"
+         inkscape:label="nostril"
+         transform="translate(4.9051967,2.824204)" />
+    </g>
+    <g
+       id="g29"
+       inkscape:label="feathers">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 118.75929,175.19485 c 0,0 5.11935,1.00836 7.72538,-0.15078 2.60603,-1.15914 1.63908,-3.26799 1.63908,-3.26799"
+         id="path27"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 127.64694,171.94532 c 0,0 3.63293,1.00836 6.23896,-0.15078 2.60603,-1.15914 1.78772,-4.0112 1.78772,-4.0112"
+         id="path28"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.30387,167.99441 c 0,0 3.63292,1.45429 6.23895,0.29515 2.60603,-1.15914 0.74723,-4.30849 0.74723,-4.30849"
+         id="path29"
+         sodipodi:nodetypes="czc" />
+    </g>
+    <path
+       d="m 233.17185,119.48995 v -10.1854 q 0,-1.8796 -1.2954,-1.8796 -0.2032,0 -0.5334,0.0508 -0.4826,0.0762 -0.6858,0.0762 -0.8128,0 -0.8128,-0.8382 0,-0.889 1.1176,-0.889 0.1778,0 0.381,0.0254 l 1.2446,0.1524 q 0.6096,0.0762 1.524,0.0762 0.635,0 1.524,-0.0762 2.0828,-0.1778 3.1496,-0.1778 1.6256,0 2.794,0.254 1.6764,0.3556 2.6162,1.5748 0.9652,1.2192 0.9652,2.9464 0,2.3876 -1.651,3.6576 -1.6256,1.27 -4.7244,1.27 h -1.8034 q -0.8382,0 -0.9906,-0.0254 h -0.0508 q -0.4064,0 -0.5334,0.1524 -0.1016,0.127 -0.1016,0.635 v 0.508 q 0,3.2258 0.1778,3.9116 0.2032,0.6858 1.1176,0.6858 0.2794,0 0.5334,-0.0762 0.5588,-0.0508 0.6858,-0.0508 0.7874,0 0.7874,0.8128 0,0.9144 -1.1176,0.9144 0,0 -0.3556,-0.0508 l -1.27,-0.1778 q -0.5334,-0.0762 -1.6002,-0.0762 -0.889,0 -1.4478,0.0762 l -1.4732,0.2032 q -0.0508,0 -0.1524,0.0254 -0.1016,0 -0.1778,0 -1.143,0 -1.143,-0.889 0,-0.3556 0.2286,-0.5842 0.2286,-0.254 0.5588,-0.254 0.2794,0 0.6858,0.0762 0.1778,0.0508 0.5334,0.0508 1.2954,0 1.2954,-1.905 z m 2.3114,-11.5062 q -0.1778,0.254 -0.1778,1.397 v 3.7592 q 0,0.6858 0.9652,0.7874 -0.0762,0 1.4732,0 1.8034,0 2.9972,-0.2794 2.2606,-0.5334 2.2606,-2.9718 0,-3.2258 -4.1148,-3.2258 -3.048,0 -3.4036,0.5334 z"
+       id="text50"
+       style="font-size:25.4px;font-family:'American Typewriter';-inkscape-font-specification:'American Typewriter, Normal';fill:#d40000;stroke-linecap:round"
+       inkscape:label="predicate"
+       transform="matrix(1,0,-0.36397023,1,-104.02112,50.379566)"
+       aria-label="P" />
+  </g>
+  <g
+     id="g50"
+     inkscape:label="objectDuck"
+     transform="translate(93.147827,46.030251)">
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 161.05072,158.22711 c 0,0 3.64426,-2.32126 3.8694,-4.81061 0.22514,-2.48935 -4.18313,-5.64723 -4.18313,-5.64723 0,0 4.83592,-2.80944 10.66699,2.61446 2.90287,4.37812 -1.77783,8.99374 -1.77783,8.99374 0,0 2.55675,-0.17341 4.18314,-2.61446 2.9859,1.95119 -3.86941,5.01976 -3.86941,5.01976 0,0 2.80956,-0.80481 4.39229,0.10457 -5.38421,3.90994 -9.37355,3.0895 -8.99373,2.82363 z"
+       id="path31"
+       sodipodi:nodetypes="czcccccccc"
+       inkscape:label="tail" />
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       d="m 103.75234,136.45366 c 0,0 -0.86503,0.6051 -5.499767,7.7294 -4.63473,7.1243 -22.020529,12.00369 -23.931412,23.33684 -1.910883,11.33314 -1.231697,27.5026 44.146769,27.79612 45.37847,0.29351 50.4654,-23.42526 46.32176,-33.51562 -4.14364,-10.09037 -33.39014,-6.87418 -41.11928,-12.41486 -7.72914,-5.54068 -4.16198,-13.37781 -4.16198,-13.37781 z"
+       id="path32"
+       sodipodi:nodetypes="czzzzzcc"
+       inkscape:label="body" />
+    <path
+       style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-dasharray:none;stroke-opacity:1"
+       d="M 83.994707,105.41335 C 81.254319,90.315858 95.5218,65.294236 122.63227,70.555556 c 5.52367,1.071976 9.23015,-2.782028 12.22671,-2.208782 1.46386,0.28004 -2.11817,4.310718 -0.83858,4.188034 3.14833,-0.301858 4.62152,-3.374149 5.92581,-2.842207 2.46671,1.006021 -3.15142,5.229714 -1.64066,6.593901 11.82665,10.679207 6.79531,33.746568 6.79531,33.746568 0,0 8.34354,0.44091 7.27404,13.59488 -1.06951,13.15397 -22.40092,15.62314 -47.13613,14.97983 -24.735208,-0.6433 -33.905352,-8.70572 -33.597891,-17.82764 0.307461,-9.12191 5.769859,-9.73285 12.353828,-15.36679 z"
+       id="path33"
+       inkscape:label="head"
+       sodipodi:nodetypes="csssscczzzc" />
+    <g
+       id="g35"
+       inkscape:label="left-eye"
+       transform="matrix(0.62866294,0.09751469,-0.10741108,0.74402699,42.717876,20.671645)">
+      <ellipse
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.23615;stroke-dasharray:none;stroke-opacity:1"
+         id="ellipse33"
+         cx="99.001656"
+         cy="97.83477"
+         rx="10.769123"
+         ry="13.991612" />
+      <ellipse
+         style="fill:#000000;stroke-width:0.264583"
+         id="ellipse34"
+         cx="100.40598"
+         cy="100.06677"
+         rx="9.1586533"
+         ry="12.211538" />
+      <ellipse
+         style="fill:#ffffff;stroke:none;stroke-width:0.0702519"
+         id="ellipse35"
+         cx="109.07626"
+         cy="88.586685"
+         rx="2.4451616"
+         ry="3.2246766"
+         transform="matrix(1.5713685,-0.05067507,-0.04433557,1.3301121,-71.105089,-18.464188)" />
+    </g>
+    <g
+       id="g38"
+       transform="matrix(0.63267818,0.09050374,-0.10756674,0.76347534,71.577528,20.169568)"
+       inkscape:label="right-eye">
+      <ellipse
+         style="fill:#ffffff;stroke:#000000;stroke-width:1.23615;stroke-dasharray:none;stroke-opacity:1"
+         id="ellipse36"
+         cx="99.001656"
+         cy="97.83477"
+         rx="10.769123"
+         ry="13.991612" />
+      <ellipse
+         style="fill:#000000;stroke-width:0.264583"
+         id="ellipse37"
+         cx="100.40598"
+         cy="100.06677"
+         rx="9.1586533"
+         ry="12.211538" />
+      <ellipse
+         style="fill:#ffffff;stroke:none;stroke-width:0.0702519"
+         id="ellipse38"
+         cx="137.85942"
+         cy="85.841255"
+         rx="2.4451616"
+         ry="3.2246766"
+         transform="matrix(1.5642008,-0.03410473,-0.04945366,1.2964292,-115.30191,-12.750004)" />
+    </g>
+    <g
+       id="g40"
+       inkscape:label="wing">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 117.13015,155.03394 c 0,0 -14.64227,7.87572 -8.17533,21.10721 6.46695,13.2315 34.39471,5.30369 36.8633,3.1215 2.4686,-2.18219 -0.14864,-3.71606 -0.14864,-3.71606"
+         id="path38"
+         sodipodi:nodetypes="czzc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 141.50749,176.43844 c 2.31332,0.16738 13.01486,-4.42879 13.97238,-8.17533 0.95752,-3.74654 -3.27013,-3.56741 -3.27013,-3.56741"
+         id="path39"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.065;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 150.15612,164.65093 c 3.05653,0.6133 13.01487,-4.42879 5.9457,-6.39162 -7.06917,-1.96284 -21.70178,-1.04049 -21.70178,-1.04049"
+         id="path40"
+         sodipodi:nodetypes="czc" />
+    </g>
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 92.455522,86.955757 c 0,0 5.176806,-2.331563 7.133926,-2.306789 1.957132,0.02477 4.608822,2.455432 4.608822,2.455432"
+       id="path41"
+       sodipodi:nodetypes="czc"
+       inkscape:label="left-brow" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 121.44079,87.996253 c 0,0 4.2275,-2.113163 6.09031,-2.083138 1.86282,0.03002 4.76057,2.380424 4.76057,2.380424"
+       id="path42"
+       sodipodi:nodetypes="czc"
+       inkscape:label="brow" />
+    <g
+       id="g46"
+       inkscape:label="beak"
+       transform="translate(-4.9051967,-2.824204)">
+      <path
+         style="fill:#ff7f2a;fill-opacity:1;stroke:#000000;stroke-width:0.665;stroke-dasharray:none;stroke-opacity:1"
+         d="m 94.413826,121.48851 c 1.75644,-1.07833 6.886274,-4.09788 10.164214,-7.65227 4.41226,-4.78436 5.05284,-7.61411 9.23152,-7.47604 4.17868,0.13807 3.81504,7.21296 5.91873,9.8659 2.10369,2.65294 8.46467,1.63456 4.9427,8.14651 -3.52198,6.51195 -8.09387,7.43378 -13.88908,8.0432 -5.79521,0.60942 -12.10693,-0.005 -16.54413,-0.88441 -4.437203,-0.87915 -8.648399,1.92835 -11.261064,0.0971 -2.612665,-1.83126 -2.972301,-2.81368 -2.972301,-2.81368 0,0 -2.254669,1.13521 -6.050376,0.42807 -3.34628,-0.62341 -5.70921,-2.9404 -5.727395,-4.98898 -0.04019,-4.52742 6.421599,-7.79125 10.786824,-7.64046 4.365225,0.15079 8.829595,3.68363 15.251716,4.72643 z"
+         id="path43"
+         sodipodi:nodetypes="cszzzzzzcsszcc"
+         inkscape:label="break" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 76.840517,127.56115 c 0,0 6.105958,-1.50986 9.955014,-1.48856 3.849056,0.0213 9.340937,2.79518 14.873329,2.91521 7.65548,0.16609 17.38607,-6.03456 17.38607,-6.03456"
+         id="path44"
+         sodipodi:nodetypes="czsc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 94.280399,121.60227 c 5.666081,1.94432 7.015801,0.71831 12.045111,2.02122"
+         id="path45"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 104.87115,116.69612 c 1.01227,-1.28957 -0.018,-0.0178 1.21733,-1.22203"
+         id="path46"
+         sodipodi:nodetypes="cc"
+         inkscape:label="nostril"
+         transform="translate(4.9051967,2.824204)" />
+    </g>
+    <g
+       id="g49"
+       inkscape:label="feathers">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 118.75929,175.19485 c 0,0 5.11935,1.00836 7.72538,-0.15078 2.60603,-1.15914 1.63908,-3.26799 1.63908,-3.26799"
+         id="path47"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 127.64694,171.94532 c 0,0 3.63293,1.00836 6.23896,-0.15078 2.60603,-1.15914 1.78772,-4.0112 1.78772,-4.0112"
+         id="path48"
+         sodipodi:nodetypes="czc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.665001;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 136.30387,167.99441 c 0,0 3.63292,1.45429 6.23895,0.29515 2.60603,-1.15914 0.74723,-4.30849 0.74723,-4.30849"
+         id="path49"
+         sodipodi:nodetypes="czc" />
+    </g>
+    <path
+       d="m 150.13303,172.71917 q -3.3782,0 -5.3594,-2.4384 -1.9558,-2.4384 -1.9558,-6.604 0,-4.2164 1.9812,-6.604 1.9812,-2.413 5.461,-2.413 3.3274,0 5.2832,2.3368 1.9812,2.3368 1.9812,6.3246 0,4.318 -2.0066,6.858 -1.9812,2.54 -5.3848,2.54 z m 0.0508,-16.2306 q -2.4384,0 -3.7846,1.8796 -1.3462,1.8796 -1.3462,5.2832 0,3.4544 1.3462,5.3594 1.3462,1.8796 3.7592,1.8796 2.3622,0 3.7338,-1.9558 1.397,-1.9812 1.397,-5.3594 0,-3.4036 -1.3208,-5.2324 -1.3208,-1.8542 -3.7846,-1.8542 z"
+       id="text51"
+       style="font-size:25.4px;font-family:'American Typewriter';-inkscape-font-specification:'American Typewriter, Normal';fill:#d40000;stroke-linecap:round"
+       inkscape:label="object"
+       transform="skewX(-20)"
+       aria-label="O" />
+  </g>
+  <metadata
+     id="metadata51">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>Duck RDF Logo</dc:title>
+        <dc:date>2026-07-19</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Nonodename</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -2,9 +2,9 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="300mm"
-   height="300mm"
-   viewBox="0 0 300 300"
+   width="231.86795mm"
+   height="189.7148mm"
+   viewBox="0 0 231.86795 189.7148"
    version="1.1"
    id="svg1"
    inkscape:version="1.4.4 (dcaf3e7, 2026-05-05)"
@@ -29,8 +29,8 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      inkscape:zoom="0.73"
-     inkscape:cx="487.67123"
-     inkscape:cy="523.28767"
+     inkscape:cx="349.31507"
+     inkscape:cy="326.0274"
      inkscape:window-width="1746"
      inkscape:window-height="1201"
      inkscape:window-x="755"
@@ -48,7 +48,7 @@
   <g
      id="g11"
      inkscape:label="subjectDuck"
-     transform="translate(-26.458333,43.855594)">
+     transform="translate(-62.988759,-8.3110742)">
     <path
        style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
        d="m 161.05072,158.22711 c 0,0 3.64426,-2.32126 3.8694,-4.81061 0.22514,-2.48935 -4.18313,-5.64723 -4.18313,-5.64723 0,0 4.83592,-2.80944 10.66699,2.61446 2.90287,4.37812 -1.77783,8.99374 -1.77783,8.99374 0,0 2.55675,-0.17341 4.18314,-2.61446 2.9859,1.95119 -3.86941,5.01976 -3.86941,5.01976 0,0 2.80956,-0.80481 4.39229,0.10457 -5.38421,3.90994 -9.37355,3.0895 -8.99373,2.82363 z"
@@ -209,7 +209,7 @@
   <g
      id="g30"
      inkscape:label="predicateDuck"
-     transform="translate(42.768266,-15.585045)">
+     transform="translate(6.23784,-67.751713)">
     <path
        style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
        d="m 161.05072,158.22711 c 0,0 3.64426,-2.32126 3.8694,-4.81061 0.22514,-2.48935 -4.18313,-5.64723 -4.18313,-5.64723 0,0 4.83592,-2.80944 10.66699,2.61446 2.90287,4.37812 -1.77783,8.99374 -1.77783,8.99374 0,0 2.55675,-0.17341 4.18314,-2.61446 2.9859,1.95119 -3.86941,5.01976 -3.86941,5.01976 0,0 2.80956,-0.80481 4.39229,0.10457 -5.38421,3.90994 -9.37355,3.0895 -8.99373,2.82363 z"
@@ -371,7 +371,7 @@
   <g
      id="g50"
      inkscape:label="objectDuck"
-     transform="translate(93.147827,46.030251)">
+     transform="translate(56.617401,-6.1364172)">
     <path
        style="fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
        d="m 161.05072,158.22711 c 0,0 3.64426,-2.32126 3.8694,-4.81061 0.22514,-2.48935 -4.18313,-5.64723 -4.18313,-5.64723 0,0 4.83592,-2.80944 10.66699,2.61446 2.90287,4.37812 -1.77783,8.99374 -1.77783,8.99374 0,0 2.55675,-0.17341 4.18314,-2.61446 2.9859,1.95119 -3.86941,5.01976 -3.86941,5.01976 0,0 2.80956,-0.80481 4.39229,0.10457 -5.38421,3.90994 -9.37355,3.0895 -8.99373,2.82363 z"
@@ -542,7 +542,26 @@
             <dc:title>Nonodename</dc:title>
           </cc:Agent>
         </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-nc-sa/4.0/" />
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-nc-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:prohibits
+           rdf:resource="http://creativecommons.org/ns#CommercialUse" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
     </rdf:RDF>
   </metadata>
 </svg>

--- a/src/execute_sparql.cpp
+++ b/src/execute_sparql.cpp
@@ -1,0 +1,55 @@
+#include "include/execute_sparql.hpp"
+#include "include/sparql_to_sql.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/parser/tableref/subqueryref.hpp"
+#include <duckdb/parser/parsed_data/create_table_function_info.hpp>
+
+namespace duckdb {
+
+// bind_replace splices the SQL translated from sparql_text/mapping_path into
+// this query's own plan as a subquery - the same mechanism DuckDB's built-in
+// query() table function uses (duckdb/src/function/table/query_function.cpp)
+// - rather than executing it as an opaque nested query. The binder recurses
+// into Bind() on the returned TableRef (bind_table_function.cpp), so filters,
+// projections, and joins written around the execute_sparql(...) call are
+// planned and optimized together with the translated SQL, not bolted on
+// afterwards.
+static unique_ptr<TableRef> ExecuteSparqlBindReplace(ClientContext &context, TableFunctionBindInput &input) {
+	auto sparql_text = input.inputs[0].GetValue<string>();
+	auto mapping_path = input.inputs[1].GetValue<string>();
+
+	std::string sql = TranslateSparqlToSql(context, sparql_text, mapping_path);
+
+	Parser parser(context.GetParserOptions());
+	parser.ParseQuery(sql);
+	if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::SELECT_STATEMENT) {
+		throw InternalException("execute_sparql: translated SQL did not parse back into a single SELECT statement "
+		                        "(generated SQL: %s)",
+		                        sql.c_str());
+	}
+	auto select_stmt = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
+	return make_uniq<SubqueryRef>(std::move(select_stmt));
+}
+
+void RegisterExecuteSparql(ExtensionLoader &loader) {
+	TableFunction tf("execute_sparql", {LogicalType::VARCHAR, LogicalType::VARCHAR}, nullptr, nullptr);
+	tf.bind_replace = ExecuteSparqlBindReplace;
+
+	CreateTableFunctionInfo info(tf);
+	FunctionDescription desc;
+	desc.description =
+	    "Translate a SPARQL SELECT or ASK query into SQL via an R2RML or YARRRML mapping (like sparql_to_sql), then "
+	    "run it directly as a table. Unlike calling sparql_to_sql() and pasting the result into a second query, "
+	    "execute_sparql() splices the translated SQL into this query's own plan before optimization, so filters, "
+	    "projections, and joins written around the call are planned together with it. Same mapping requirements "
+	    "and error messages as sparql_to_sql().";
+	desc.examples.push_back("SELECT * FROM execute_sparql('SELECT ?e ?name WHERE { ?e "
+	                        "<http://example.com/ns#name> ?name }', 'mapping.ttl')");
+	info.descriptions.push_back(desc);
+	loader.RegisterFunction(std::move(info));
+}
+
+} // namespace duckdb

--- a/src/include/execute_sparql.hpp
+++ b/src/include/execute_sparql.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+void RegisterExecuteSparql(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/include/sparql_to_sql.hpp
+++ b/src/include/sparql_to_sql.hpp
@@ -2,9 +2,16 @@
 
 #include "duckdb.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include <string>
 
 namespace duckdb {
 
 void RegisterSparqlToSql(ExtensionLoader &loader);
+
+// Loads mapping_path, parses sparql_text, and translates it into a standalone
+// SQL query for the "duckdb" dialect. Shared by the sparql_to_sql scalar
+// function and execute_sparql's bind_replace so both raise identical errors.
+std::string TranslateSparqlToSql(ClientContext &context, const std::string &sparql_text,
+                                 const std::string &mapping_path);
 
 } // namespace duckdb

--- a/src/rdf_extension.cpp
+++ b/src/rdf_extension.cpp
@@ -8,6 +8,7 @@
 #endif
 #include "include/r2rml_copy.hpp"
 #include "include/sparql_to_sql.hpp"
+#include "include/execute_sparql.hpp"
 #include "include/profile_rdf.hpp"
 #include "include/pivot_rdf.hpp"
 #include "include/read_rdf_prefixes.hpp"
@@ -406,6 +407,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	RegisterR2RMLCopy(loader);
 	RegisterSparqlToSql(loader);
+	RegisterExecuteSparql(loader);
 #ifndef DUCK_RDF_NO_SPARQL
 	RegisterSPARQLReader(loader);
 #endif

--- a/src/sparql_to_sql.cpp
+++ b/src/sparql_to_sql.cpp
@@ -18,52 +18,57 @@ static std::string DescribeParseError(const sparql::ParseError &e) {
 	       std::to_string(e.column()) + ", near '" + e.nearText() + "')";
 }
 
+std::string TranslateSparqlToSql(ClientContext &context, const std::string &sparql_text,
+                                 const std::string &mapping_path) {
+	auto &fs = FileSystem::GetFileSystem(context);
+	if (!fs.FileExists(mapping_path)) {
+		throw IOException("Mapping file not found: " + mapping_path);
+	}
+
+	r2rml::R2RMLMapping mapping;
+	try {
+		mapping = ParseR2RMLOrYarrrmlMapping(mapping_path);
+	} catch (const std::runtime_error &e) {
+		throw InvalidInputException("R2RML/YARRRML mapping parse error: %s", e.what());
+	}
+
+	if (!mapping.isValid()) {
+		throw InvalidInputException(
+		    "Mapping '%s' is not a valid full R2RML mapping. sparql_to_sql() translates a SPARQL query into "
+		    "a standalone SQL query, so every TriplesMap in the mapping must declare an rr:logicalTable (or "
+		    "YARRRML 'sources') naming the table/view to query. An inside-out-only mapping (one that "
+		    "can_call_inside_out() accepts but is_valid_r2rml() rejects) is not sufficient here.",
+		    mapping_path.c_str());
+	}
+
+	std::unique_ptr<sparql::ast::Query> query;
+	try {
+		sparql::Parser parser;
+		query = parser.parseString(sparql_text);
+	} catch (const sparql::ParseError &e) {
+		throw InvalidInputException(DescribeParseError(e));
+	} catch (const std::exception &e) {
+		throw InvalidInputException("SPARQL parse error: %s", e.what());
+	}
+
+	std::string sql;
+	try {
+		sparql2sql::DuckDbDialect dialect;
+		sql = sparql2sql::translateQuery(*query, mapping, dialect);
+	} catch (const std::exception &e) {
+		throw InvalidInputException("SPARQL-to-SQL translation error: %s", e.what());
+	}
+
+	return sql;
+}
+
 inline void SparqlToSql(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &sparql_vector = args.data[0];
 	auto &mapping_vector = args.data[1];
 	BinaryExecutor::Execute<string_t, string_t, string_t>(
 	    sparql_vector, mapping_vector, result, args.size(), [&](string_t sparql_text, string_t mapping_path_str) {
-		    std::string mapping_path = mapping_path_str.GetString();
-
-		    auto &fs = FileSystem::GetFileSystem(state.GetContext());
-		    if (!fs.FileExists(mapping_path)) {
-			    throw IOException("Mapping file not found: " + mapping_path);
-		    }
-
-		    r2rml::R2RMLMapping mapping;
-		    try {
-			    mapping = ParseR2RMLOrYarrrmlMapping(mapping_path);
-		    } catch (const std::runtime_error &e) {
-			    throw InvalidInputException("R2RML/YARRRML mapping parse error: %s", e.what());
-		    }
-
-		    if (!mapping.isValid()) {
-			    throw InvalidInputException(
-			        "Mapping '%s' is not a valid full R2RML mapping. sparql_to_sql() translates a SPARQL query into "
-			        "a standalone SQL query, so every TriplesMap in the mapping must declare an rr:logicalTable (or "
-			        "YARRRML 'sources') naming the table/view to query. An inside-out-only mapping (one that "
-			        "can_call_inside_out() accepts but is_valid_r2rml() rejects) is not sufficient here.",
-			        mapping_path.c_str());
-		    }
-
-		    std::unique_ptr<sparql::ast::Query> query;
-		    try {
-			    sparql::Parser parser;
-			    query = parser.parseString(sparql_text.GetString());
-		    } catch (const sparql::ParseError &e) {
-			    throw InvalidInputException(DescribeParseError(e));
-		    } catch (const std::exception &e) {
-			    throw InvalidInputException("SPARQL parse error: %s", e.what());
-		    }
-
-		    std::string sql;
-		    try {
-			    sparql2sql::DuckDbDialect dialect;
-			    sql = sparql2sql::translateQuery(*query, mapping, dialect);
-		    } catch (const std::exception &e) {
-			    throw InvalidInputException("SPARQL-to-SQL translation error: %s", e.what());
-		    }
-
+		    std::string sql =
+		        TranslateSparqlToSql(state.GetContext(), sparql_text.GetString(), mapping_path_str.GetString());
 		    return StringVector::AddString(result, sql);
 	    });
 }

--- a/test/sql/execute_sparql.test
+++ b/test/sql/execute_sparql.test
@@ -1,0 +1,136 @@
+# name: test/sql/execute_sparql.test
+# description: test execute_sparql dynamic SPARQL-to-SQL execution
+# group: [sql]
+
+require rdf
+
+# ── Setup ─────────────────────────────────────────────────────────────────────
+# Same table shape as sparql_to_sql.test, mapped by test/r2rml/full_r2rml_lower.ttl
+# (rr:logicalTable [ rr:tableName "emp" ], lowercase column refs matching
+# DuckDB's unquoted-identifier folding).
+
+statement ok
+CREATE TABLE emp AS SELECT 7369 AS EMPNO, 'SMITH' AS ENAME, 10 AS DEPTNO;
+
+# ── Success: execute directly ────────────────────────────────────────────────
+# Same query/mapping as sparql_to_sql.test's round-trip test, but run directly
+# through execute_sparql instead of pasting the generated SQL by hand.
+
+query TT
+SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'test/r2rml/full_r2rml_lower.ttl'
+);
+----
+http://data.example.com/employee/7369	SMITH
+
+# Same query/mapping via YARRRML (.yml) — proves format-by-extension dispatch
+# produces the same result via this path too.
+query TT
+SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'test/r2rml/full_r2rml_lower.yml'
+);
+----
+http://data.example.com/employee/7369	SMITH
+
+# ── Success: composes as a real subquery ─────────────────────────────────────
+# Column names are the SPARQL variable names, prefixed v_ by the translator.
+
+query T
+SELECT v_name FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'test/r2rml/full_r2rml_lower.ttl'
+) WHERE v_e = 'http://data.example.com/employee/7369';
+----
+SMITH
+
+# Column-name aliasing (AS t(id, name)) is handled by DuckDB's binder before
+# bind_replace's TableRef is bound, so it works transparently.
+query T
+SELECT t.name FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'test/r2rml/full_r2rml_lower.ttl'
+) AS t(id, name);
+----
+SMITH
+
+# Joins with another table: proves execute_sparql(...) behaves as a genuine
+# subquery in the surrounding plan, not an opaque scan.
+statement ok
+CREATE TABLE dept AS SELECT 10 AS DEPTNO, 'ACCOUNTING' AS DNAME;
+
+query T
+SELECT dept.dname
+FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'test/r2rml/full_r2rml_lower.ttl'
+) AS t(id, name)
+JOIN dept ON dept.deptno = 10;
+----
+ACCOUNTING
+
+# ── Plan-merging proof ───────────────────────────────────────────────────────
+# execute_sparql's bind_replace splices the translated SQL in as a subquery
+# before optimization, so the physical plan scans "emp" directly - there is no
+# separate execute_sparql table-function-scan node in the plan at all.
+
+query II
+EXPLAIN SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'test/r2rml/full_r2rml_lower.ttl'
+);
+----
+physical_plan	<REGEX>:.*emp.*
+
+# ── Error cases ───────────────────────────────────────────────────────────────
+# Identical to sparql_to_sql.test's error cases: execute_sparql shares the
+# TranslateSparqlToSql helper, so the same errors are raised the same way.
+
+# mapping file not found
+statement error
+SELECT * FROM execute_sparql('SELECT ?e WHERE { ?e ?p ?o }', 'test/r2rml/nonexistent.ttl');
+----
+Mapping file not found
+
+# mapping is inside-out-only (no rr:logicalTable) - not enough for translation
+statement error
+SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }',
+    'test/r2rml/inside_out.ttl'
+);
+----
+not a valid full R2RML mapping
+
+# malformed SPARQL syntax
+statement error
+SELECT * FROM execute_sparql('SELECT ?e WHERE { ?e ?p ?o', 'test/r2rml/full_r2rml_lower.ttl');
+----
+SPARQL parse error
+
+# unsupported query form: CONSTRUCT
+statement error
+SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> CONSTRUCT { ?e ex:name ?name } WHERE { ?e ex:name ?name }',
+    'test/r2rml/full_r2rml_lower.ttl'
+);
+----
+SPARQL-to-SQL translation error
+
+# unsupported construct: GRAPH pattern (R2RML mappings carry no named-graph info)
+statement error
+SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { GRAPH ?g { ?e ex:name ?name } }',
+    'test/r2rml/full_r2rml_lower.ttl'
+);
+----
+GRAPH patterns require named-graph support
+
+# unsupported construct: property path in predicate position
+statement error
+SELECT * FROM execute_sparql(
+    'PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name+ ?name }',
+    'test/r2rml/full_r2rml_lower.ttl'
+);
+----
+property paths are not supported

--- a/test/sql/function_metadata.test
+++ b/test/sql/function_metadata.test
@@ -99,3 +99,15 @@ query I
 SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'sparql_to_sql' LIMIT 1;
 ----
 true
+
+# ── execute_sparql ────────────────────────────────────────────────────────────
+
+query I
+SELECT description IS NOT NULL FROM duckdb_functions() WHERE function_name = 'execute_sparql' LIMIT 1;
+----
+true
+
+query I
+SELECT len(examples) > 0 FROM duckdb_functions() WHERE function_name = 'execute_sparql' LIMIT 1;
+----
+true


### PR DESCRIPTION
`sparql_to_sql(sparql, mapping)` translates a SPARQL query into SQL text, but running it required copying that string into a second query. This PR adds `execute_sparql(sparql, mapping)`, a table function that does both steps in one call.

The interesting part: `execute_sparql` doesn't execute the translated SQL as an opaque nested query. It uses DuckDB's `TableFunction::bind_replace` mechanism — the same one behind DuckDB's own built-in `query()` table function — to return a parsed `SubqueryRef` from the bind step instead of normal bind data. DuckDB's `binder` then recurses into it using the same Binder, so the translated SQL becomes a genuine subquery in the calling query's plan before optimization runs. Filters, projections, and joins written around the `execute_sparql(...)` call get pushed into the same plan DuckDB would build had the SQL been pasted in by hand — confirmed via `EXPLAIN`, which shows filters pushed all the way down to the physical scan of the underlying mapped table, with no separate table-function-scan node in the plan at all.

Changes
* `src/sparql_to_sql.cpp` / `.hpp:` extracted the mapping-load → validate → SPARQL-parse → translate pipeline into a shared `TranslateSparqlToSql()` helper, so the scalar function and the new table function raise byte-for-byte identical errors.
* `src/execute_sparql.cpp` / `.hpp` (new): registers `execute_sparql` with a `bind_replace` callback that calls `TranslateSparqlToSql()`, parses the result with `Parser::ParseQuery`, and returns it wrapped in a `SubqueryRef`.
* `CMakeLists.txt`, `src/rdf_extension.cpp`: wired in unconditionally, alongside `sparql_to_sql `— same dependency profile (no curl/libxml2), so it's WASM-compatible too.
* `test/sql/execute_sparql.test` (new): success cases (Turtle + YARRRML mappings), subquery composition (column aliasing, joins), an `EXPLAIN`-based proof that the plan is fused, and the same error-path coverage as `sparql_to_sql.test`.
* `test/sql/function_metadata.test`: added `execute_sparql` to the `duckdb_functions()` metadata checks.
* `docs/functions.md`,` README.md,` `.claude/CLAUDE.md`: documented the function and the `bind_replace` mechanism.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nonodename/duck_rdf/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->