### PR TITLE
Restore prior allow_parser_override_extension setting on disable_sparql_parser

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -506,6 +506,7 @@ Internally, this hooks into DuckDB's parser via a `ParserExtension`: any stateme
 
 - This is a **database-wide** toggle, not a per-connection setting: it affects every connection to the same DuckDB database, not just the session that called `enable_sparql_parser`. There is no per-connection variant, since the underlying parser hook has no notion of which connection is asking.
 - Only one mapping can be active at a time; calling `enable_sparql_parser` again replaces the previous mapping.
+- `enable_sparql_parser` works by setting the database-wide `allow_parser_override_extension` setting to `STRICT`. It remembers whatever value that setting had immediately before the first `enable_sparql_parser` call, and `disable_sparql_parser` restores exactly that value — so any pre-existing configuration of `allow_parser_override_extension` (set by you or another extension) survives an enable/disable cycle instead of being reset to `DEFAULT`.
 - Text that fails to parse as SPARQL at all falls straight through to DuckDB's normal SQL parser (so plain SQL keeps working); text that parses as SPARQL but then fails translation (bad mapping, unsupported construct) raises the same errors `sparql_to_sql`/`execute_sparql` would.
 - In the Duck CLI any `;` in the query immeadiate terminates parsing. You can escape those using `$$` boundary markers (e.g `$$ ; $$`). This is one of those 'because we could' features, your mileage will vary.
 

--- a/src/sparql_parser.cpp
+++ b/src/sparql_parser.cpp
@@ -157,7 +157,7 @@ static unique_ptr<FunctionData> EnableSparqlParserBind(ClientContext &context, T
 			// disabled to enabled, so a re-enable (e.g. to swap mappings)
 			// doesn't clobber the originally saved value with STRICT.
 			Value current_value;
-			if(config.TryGetCurrentSetting("allow_parser_override_extension", current_value)){
+			if (config.TryGetCurrentSetting("allow_parser_override_extension", current_value)) {
 				state.saved_override_setting = current_value;
 				state.has_saved_override_setting = true;
 			}
@@ -191,10 +191,10 @@ static unique_ptr<FunctionData> DisableSparqlParserBind(ClientContext &context, 
 			state.has_saved_override_setting = false;
 		}
 	}
-	if(wasEnabled){ // only restore if was enabled to avoid clobbering another package installed state
+	if (wasEnabled) { // only restore if was enabled to avoid clobbering another package installed state
 		DBConfig::GetConfig(context).SetOptionByName("allow_parser_override_extension", restore_value);
 	}
-	
+
 	names = {"sparql_parser_enabled"};
 	return_types = {LogicalType::BOOLEAN};
 	auto result = make_uniq<SparqlParserToggleData>();

--- a/src/sparql_parser.cpp
+++ b/src/sparql_parser.cpp
@@ -27,6 +27,11 @@ struct SparqlParserState : public ParserExtensionInfo, public TableFunctionInfo 
 	std::mutex mutex;
 	bool enabled = false;
 	std::string mapping_path;
+	// The value of allow_parser_override_extension in effect just before the
+	// first enable_sparql_parser() call flipped it to STRICT, so
+	// disable_sparql_parser() can restore it instead of assuming DEFAULT.
+	bool has_saved_override_setting = false;
+	Value saved_override_setting;
 };
 
 // parser_override receives the raw statement text exactly as submitted,
@@ -143,15 +148,25 @@ static unique_ptr<FunctionData> EnableSparqlParserBind(ClientContext &context, T
 		    mapping_path.c_str());
 	}
 
+	auto &config = DBConfig::GetConfig(context);
 	auto &state = *static_cast<SparqlParserState *>(input.info.get());
 	{
 		std::lock_guard<std::mutex> lock(state.mutex);
+		if (!state.enabled) {
+			// Only capture the pre-existing setting on the transition from
+			// disabled to enabled, so a re-enable (e.g. to swap mappings)
+			// doesn't clobber the originally saved value with STRICT.
+			Value current_value;
+			config.TryGetCurrentSetting("allow_parser_override_extension", current_value);
+			state.saved_override_setting = current_value;
+			state.has_saved_override_setting = true;
+		}
 		state.enabled = true;
 		state.mapping_path = mapping_path;
 	}
 	// parser_override only runs when allow_parser_override_extension is not
 	// DEFAULT - flip it to STRICT so bare SPARQL statements actually reach it.
-	DBConfig::GetConfig(context).SetOptionByName("allow_parser_override_extension", Value("STRICT"));
+	config.SetOptionByName("allow_parser_override_extension", Value("STRICT"));
 
 	names = {"sparql_parser_enabled"};
 	return_types = {LogicalType::BOOLEAN};
@@ -163,12 +178,17 @@ static unique_ptr<FunctionData> EnableSparqlParserBind(ClientContext &context, T
 static unique_ptr<FunctionData> DisableSparqlParserBind(ClientContext &context, TableFunctionBindInput &input,
                                                         vector<LogicalType> &return_types, vector<string> &names) {
 	auto &state = *static_cast<SparqlParserState *>(input.info.get());
+	Value restore_value("DEFAULT");
 	{
 		std::lock_guard<std::mutex> lock(state.mutex);
 		state.enabled = false;
 		state.mapping_path.clear();
+		if (state.has_saved_override_setting) {
+			restore_value = state.saved_override_setting;
+			state.has_saved_override_setting = false;
+		}
 	}
-	DBConfig::GetConfig(context).SetOptionByName("allow_parser_override_extension", Value("DEFAULT"));
+	DBConfig::GetConfig(context).SetOptionByName("allow_parser_override_extension", restore_value);
 
 	names = {"sparql_parser_enabled"};
 	return_types = {LogicalType::BOOLEAN};

--- a/src/sparql_parser.cpp
+++ b/src/sparql_parser.cpp
@@ -157,9 +157,10 @@ static unique_ptr<FunctionData> EnableSparqlParserBind(ClientContext &context, T
 			// disabled to enabled, so a re-enable (e.g. to swap mappings)
 			// doesn't clobber the originally saved value with STRICT.
 			Value current_value;
-			config.TryGetCurrentSetting("allow_parser_override_extension", current_value);
-			state.saved_override_setting = current_value;
-			state.has_saved_override_setting = true;
+			if(config.TryGetCurrentSetting("allow_parser_override_extension", current_value)){
+				state.saved_override_setting = current_value;
+				state.has_saved_override_setting = true;
+			}
 		}
 		state.enabled = true;
 		state.mapping_path = mapping_path;
@@ -179,8 +180,10 @@ static unique_ptr<FunctionData> DisableSparqlParserBind(ClientContext &context, 
                                                         vector<LogicalType> &return_types, vector<string> &names) {
 	auto &state = *static_cast<SparqlParserState *>(input.info.get());
 	Value restore_value("DEFAULT");
+	auto wasEnabled = false;
 	{
 		std::lock_guard<std::mutex> lock(state.mutex);
+		wasEnabled = state.enabled;
 		state.enabled = false;
 		state.mapping_path.clear();
 		if (state.has_saved_override_setting) {
@@ -188,8 +191,10 @@ static unique_ptr<FunctionData> DisableSparqlParserBind(ClientContext &context, 
 			state.has_saved_override_setting = false;
 		}
 	}
-	DBConfig::GetConfig(context).SetOptionByName("allow_parser_override_extension", restore_value);
-
+	if(wasEnabled){ // only restore if was enabled to avoid clobbering another package installed state
+		DBConfig::GetConfig(context).SetOptionByName("allow_parser_override_extension", restore_value);
+	}
+	
 	names = {"sparql_parser_enabled"};
 	return_types = {LogicalType::BOOLEAN};
 	auto result = make_uniq<SparqlParserToggleData>();

--- a/test/sql/sparql_parser.test
+++ b/test/sql/sparql_parser.test
@@ -90,3 +90,40 @@ statement error
 PREFIX ex: <http://example.com/ns#> SELECT ?e ?name WHERE { ?e ex:name ?name }
 ----
 Parser Error
+
+# ── Pre-existing allow_parser_override_extension setting is preserved ─────────
+# (see issue #73: disable_sparql_parser() must restore whatever value was in
+# effect before the first enable, not hard-code DEFAULT).
+
+statement ok
+SET allow_parser_override_extension = 'FALLBACK';
+
+query I
+CALL enable_sparql_parser('test/r2rml/full_r2rml_lower.ttl');
+----
+true
+
+query I
+SELECT current_setting('allow_parser_override_extension');
+----
+STRICT
+
+# Re-enabling (e.g. to swap mappings) while already enabled must not clobber
+# the originally saved 'FALLBACK' value with the current 'STRICT' one.
+query I
+CALL enable_sparql_parser('test/r2rml/full_r2rml_lower.ttl');
+----
+true
+
+query I
+CALL disable_sparql_parser();
+----
+false
+
+query I
+SELECT current_setting('allow_parser_override_extension');
+----
+FALLBACK
+
+statement ok
+SET allow_parser_override_extension = 'DEFAULT';


### PR DESCRIPTION
Fixes #73: enable_sparql_parser() now captures whatever value
allow_parser_override_extension had immediately before the first enable
(not on subsequent re-enables), and disable_sparql_parser() restores
that exact value instead of hard-coding DEFAULT, so pre-existing user
or other-extension configuration of the setting survives an
enable/disable cycle.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0131EHid15GQBu5bVx59tQ7N
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nonodename/duck_rdf/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->